### PR TITLE
fix issue with merge function

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1168,6 +1168,7 @@ k8s.io/apimachinery v0.17.2/go.mod h1:b9qmWdKlLuU9EBh+06BtLcSf/Mu89rWL33naRxs1uZ
 k8s.io/apimachinery v0.17.3/go.mod h1:gxLnyZcGNdZTCLnq3fgzyg2A5BVCHTNDFrw8AmuJ+0g=
 k8s.io/apimachinery v0.17.4 h1:UzM+38cPUJnzqSQ+E1PY4YxMHIzQyCg29LOoGfo79Zw=
 k8s.io/apimachinery v0.17.4/go.mod h1:gxLnyZcGNdZTCLnq3fgzyg2A5BVCHTNDFrw8AmuJ+0g=
+k8s.io/apimachinery v0.18.3 h1:pOGcbVAhxADgUYnjS08EFXs9QMl8qaH5U4fr5LGUrSk=
 k8s.io/apiserver v0.0.0-20190918160949-bfa5e2e684ad/go.mod h1:XPCXEwhjaFN29a8NldXA901ElnKeKLrLtREO9ZhFyhg=
 k8s.io/apiserver v0.16.7/go.mod h1:/5zSatF30/L9zYfMTl55jzzOnx7r/gGv5a5wtRp8yAw=
 k8s.io/apiserver v0.17.0/go.mod h1:ABM+9x/prjINN6iiffRVNCBR2Wk7uY4z+EtEGZD48cg=

--- a/pkg/controller/configurationpolicy/configurationpolicy_controller.go
+++ b/pkg/controller/configurationpolicy/configurationpolicy_controller.go
@@ -1104,11 +1104,15 @@ func compareLists(newList []interface{}, oldList []interface{}, ctype string) (u
 	//mustonlyhave
 	mergedList := []interface{}{}
 	for idx, item := range newList {
-		newItem, err := mergeSpecs(item, oldList[idx], ctype)
-		if err != nil {
-			return nil, err
+		if idx < len(oldList) {
+			newItem, err := mergeSpecs(item, oldList[idx], ctype)
+			if err != nil {
+				return nil, err
+			}
+			mergedList = append(mergedList, newItem)
+		} else {
+			mergedList = append(mergedList, item)
 		}
-		mergedList = append(mergedList, newItem)
 	}
 	return mergedList, nil
 }


### PR DESCRIPTION
- mustonlyhave fails if the length of the template is longer than the length of the rules in the role