### PR TITLE
do not double update status for single obj compliant

### DIFF
--- a/pkg/controller/configurationpolicy/configurationpolicy_controller.go
+++ b/pkg/controller/configurationpolicy/configurationpolicy_controller.go
@@ -558,12 +558,16 @@ func handleObjects(objectT *policyv1.ObjectTemplate, namespace string, index int
 		}
 		if !exists && !objShouldExist {
 			//it is a must not have and it does not exist, so it is compliant
-			updateNeeded = handleMissingMustNotHave(policy, index, name, rsrc)
+			if strings.ToLower(string(remediation)) == strings.ToLower(string(policyv1.Enforce)) {
+				updateNeeded = handleMissingMustNotHave(policy, index, name, rsrc)
+			}
 			compliant = true
 		}
 		if exists && objShouldExist {
 			//it is a must have and it does exist, so it is compliant
-			updateNeeded = handleExistsMustHave(policy, index, name, rsrc)
+			if strings.ToLower(string(remediation)) == strings.ToLower(string(policyv1.Enforce)) {
+				updateNeeded = handleExistsMustHave(policy, index, name, rsrc)
+			}
 			compliant = true
 		}
 


### PR DESCRIPTION
fixes reconcile error `Operation cannot be fulfilled on configurationpolicies.policies.open-cluster-management.io \"policy-imagemanifestvulnpolicy-example-csv\": the object has been modified; please apply your changes to the latest version and try again","error":"Operation cannot be fulfilled on configurationpolicies.policies.open-cluster-management.io \"policy-imagemanifestvulnpolicy-example-csv\": the object has been modified; please apply your changes to the latest version and try again","stacktrace":"github.com/go-logr/zapr.(*zapLogger).Error\n\t/home/travis/gopath/pkg/mod/github.com/go-logr/zapr@v0.1.1/zapr.go:128\ngithub.com/open-cluster-management/config-policy-controller/pkg/controller/configurationpolicy.addForUpdate\n\tconfig-policy-controller/pkg/controller/configurationpolicy/configurationpolicy_controller.go:1334\ngithub.com/open-cluster-management/config-policy-controller/pkg/controller/configurationpolicy.handleObjectTemplates\n\tconfig-policy-controller/pkg/controller/configurationpolicy/configurationpolicy_controller.go:370\ngithub.com/open-cluster-management/config-policy-controller/pkg/controller/configurationpolicy.PeriodicallyExecConfigPolicies\n\tconfig-policy-controller/pkg/controller/configurationpolicy/configurationpolicy_controller.go:179`