### PR TITLE
error and create violation if there is a type mismatch

### DIFF
--- a/pkg/controller/configurationpolicy/configurationpolicy_controller.go
+++ b/pkg/controller/configurationpolicy/configurationpolicy_controller.go
@@ -1124,14 +1124,16 @@ func handleKeys(unstruct unstructured.Unstructured, existingObj *unstructured.Un
 				case []interface{}:
 					mergedObj, err = compareLists(newObj, oldObj, complianceType)
 				default:
-					typeErr = fmt.Sprintf("Error merging changes into key \"%s\": object type of template and existing do not match", key)
+					typeErr = fmt.Sprintf("Error merging changes into key \"%s\": object type of template and existing do not match",
+						key)
 				}
 			case map[string]interface{}:
 				switch oldObj := oldObj.(type) {
 				case (map[string]interface{}):
 					mergedObj, err = compareSpecs(newObj, oldObj, complianceType)
 				default:
-					typeErr = fmt.Sprintf("Error merging changes into key \"%s\": object type of template and existing do not match", key)
+					typeErr = fmt.Sprintf("Error merging changes into key \"%s\": object type of template and existing do not match",
+						key)
 				}
 			default:
 				mergedObj = newObj


### PR DESCRIPTION
previously, if there was a type mismatch where a field was a map or list when it shouldn't be, the entire controller would crash (see https://github.com/open-cluster-management/backlog/issues/3695#issuecomment-661968978)