### PR TITLE
avoid adding a resource to relatedObjects multiple times

### DIFF
--- a/pkg/controller/configurationpolicy/configurationpolicy_controller.go
+++ b/pkg/controller/configurationpolicy/configurationpolicy_controller.go
@@ -358,7 +358,7 @@ func handleObjectTemplates(plc policyv1.ConfigurationPolicy, apiresourcelist []*
 			}
 			if related != nil {
 				for _, object := range related {
-					relatedObjects = append(relatedObjects, object)
+					relatedObjects = updateRelatedObjectsStatus(relatedObjects, object)
 				}
 			}
 		}


### PR DESCRIPTION
fixes issue where cluster-level objects would be added to relatedObjects once for each namespace the policy was in

https://github.com/open-cluster-management/backlog/issues/6630