### PR TITLE
Handle empty names array - 8289

### DIFF
--- a/pkg/controller/configurationpolicy/configurationpolicy_utils.go
+++ b/pkg/controller/configurationpolicy/configurationpolicy_utils.go
@@ -184,13 +184,17 @@ func createResourceNameStr(names []string, namespace string, namespaced bool) (n
 			nameStr += ", "
 		}
 	}
-	nameStr += "] "
+	nameStr += "]"
 	// No names found--return empty string instead
-	if nameStr == "[] " {
+	if nameStr == "[]" {
 		nameStr = ""
 	}
 	// Add namespace
 	if namespaced {
+		// Add a space if there are names
+		if nameStr != "" {
+			nameStr += " "
+		}
 		nameStr += "in namespace " + namespace
 	}
 	return nameStr


### PR DESCRIPTION
Continuation from PR #81

Fixes issue where no names prints empty brackets:
```
Compliant; notification - events [] in namespace gatekeeper-system missing as expected, therefore this Object template is compliant
```
...changed to...
```
Compliant; notification - events in namespace gatekeeper-system missing as expected, therefore this Object template is compliant
```