### PR TITLE
need this preserve flag in the v1 crds

### DIFF
--- a/deploy/crds/v1/policy.open-cluster-management.io_configurationpolicies.yaml
+++ b/deploy/crds/v1/policy.open-cluster-management.io_configurationpolicies.yaml
@@ -58,6 +58,7 @@ spec:
                     objectDefinition:
                       description: ObjectDefinition defines required fields for the object
                       type: object
+                      x-kubernetes-preserve-unknown-fields: true
                   required:
                   - complianceType
                   type: object

--- a/pkg/apis/policy/v1/configurationpolicy_types.go
+++ b/pkg/apis/policy/v1/configurationpolicy_types.go
@@ -77,6 +77,7 @@ type ObjectTemplate struct {
 	ComplianceType ComplianceType `json:"complianceType"`
 
 	// ObjectDefinition defines required fields for the object
+	// +kubebuilder:pruning:PreserveUnknownFields
 	ObjectDefinition runtime.RawExtension `json:"objectDefinition,omitempty"`
 }
 


### PR DESCRIPTION
The config policy does not work properly without preserving some existing fields.  This behaves differently than the upgrade scenario for v1beta1 to v1 so I didn't catch it initially.
This fix will be needed for issue https://github.com/open-cluster-management/backlog/issues/9739 too