### PR TITLE
do not patch existing lists with the sorted version

### DIFF
--- a/pkg/controller/configurationpolicy/configurationpolicy_utils.go
+++ b/pkg/controller/configurationpolicy/configurationpolicy_utils.go
@@ -111,7 +111,6 @@ func checkFieldsWithSort(mergedObj map[string]interface{}, oldObj map[string]int
 }
 
 func checkListFieldsWithSort(mergedObj []map[string]interface{}, oldObj []map[string]interface{}) (matches bool) {
-	fmt.Println("in checklistfields ---------------")
 	sort.Slice(oldObj, func(i, j int) bool {
 		return fmt.Sprintf("%v", oldObj[i]) < fmt.Sprintf("%v", oldObj[j])
 	})

--- a/pkg/controller/configurationpolicy/configurationpolicy_utils.go
+++ b/pkg/controller/configurationpolicy/configurationpolicy_utils.go
@@ -111,6 +111,7 @@ func checkFieldsWithSort(mergedObj map[string]interface{}, oldObj map[string]int
 }
 
 func checkListFieldsWithSort(mergedObj []map[string]interface{}, oldObj []map[string]interface{}) (matches bool) {
+	fmt.Println("in checklistfields ---------------")
 	sort.Slice(oldObj, func(i, j int) bool {
 		return fmt.Sprintf("%v", oldObj[i]) < fmt.Sprintf("%v", oldObj[j])
 	})
@@ -158,7 +159,9 @@ func checkListFieldsWithSort(mergedObj []map[string]interface{}, oldObj []map[st
 	return match
 }
 
-func checkListsMatch(oVal []interface{}, mVal []interface{}) (m bool) {
+func checkListsMatch(oldVal []interface{}, mergedVal []interface{}) (m bool) {
+	oVal := append([]interface{}{}, oldVal...)
+	mVal := append([]interface{}{}, mergedVal...)
 	if (oVal == nil && mVal != nil) || (oVal != nil && mVal == nil) {
 		return false
 	}

--- a/test/e2e/case7_no_spec_test.go
+++ b/test/e2e/case7_no_spec_test.go
@@ -101,7 +101,7 @@ var _ = Describe("Test cluster version obj template handling", func() {
 		})
 		It("should handle change field to null", func() {
 			By("Creating " + case7ConfigPolicyNameNull + " on managed")
-			utils.Kubectl("apply", "-f", case7PolicyYamlNull, "-n", testNamespace)
+			utils.Kubectl("apply", "-f", case7PolicyYamlNull, "-n", testNamespace, "--validate=false")
 			plc := utils.GetWithTimeout(clientManagedDynamic, gvrConfigPolicy, case7ConfigPolicyNameNull, testNamespace, true, defaultTimeoutSeconds)
 			Expect(plc).NotTo(BeNil())
 			Eventually(func() interface{} {


### PR DESCRIPTION
should fix e2e test failures