### PR TITLE
change the way compliance is handled across multiple namespaces

### DIFF
--- a/pkg/controller/configurationpolicy/configurationpolicy_controller.go
+++ b/pkg/controller/configurationpolicy/configurationpolicy_controller.go
@@ -481,34 +481,31 @@ func createInformStatus(mustNotHave bool, numCompliant int, numNonCompliant int,
 	if kind == "" {
 		return
 	}
-	// We want resources to exist, but none were found
-	if !mustNotHave && numCompliant == 0 && numNonCompliant == 0 {
-		//noncompliant; musthave and objects do not exist
-		update = createMustHaveStatus(desiredName, kind, nonCompliantObjects, namespaced,
-			plc, indx, compliant)
+
+	if mustNotHave {
+		if numNonCompliant > 0 { // We want no resources, but some were found
+			//noncompliant; mustnothave and objects exist
+			update = createMustNotHaveStatus(kind, nonCompliantObjects, namespaced, plc, indx, compliant)
+		} else if numNonCompliant == 0 {
+			//compliant; mustnothave and no objects exist
+			compliant = true
+			update = createMustNotHaveStatus(kind, compliantObjects, namespaced, plc, indx, compliant)
+		}
+	} else { // !mustNotHave (musthave)
+		if numCompliant == 0 && numNonCompliant == 0 { // Special case: No resources found is NonCompliant
+			//noncompliant; musthave and objects do not exist
+			update = createMustHaveStatus(desiredName, kind, nonCompliantObjects, namespaced,
+				plc, indx, compliant)
+		} else if numNonCompliant > 0 {
+			//noncompliant; musthave and some objects do not exist
+			update = createMustHaveStatus("", kind, nonCompliantObjects, namespaced, plc, indx, compliant)
+		} else { // Found only compliant resources (numCompliant > 0 and no NonCompliant)
+			//compliant; musthave and objects exist
+			compliant = true
+			update = createMustHaveStatus("", kind, compliantObjects, namespaced, plc, indx, compliant)
+		}
 	}
-	// We want no resources, but some were found
-	if mustNotHave && numNonCompliant > 0 {
-		//noncompliant; mustnothave and objects exist
-		update = createMustNotHaveStatus(kind, nonCompliantObjects, namespaced, plc, indx, compliant)
-	}
-	// We want resources and we found them
-	if !mustNotHave && numCompliant > 0 && numNonCompliant == 0 {
-		//compliant; musthave and objects exist
-		compliant = true
-		update = createMustHaveStatus("", kind, compliantObjects, namespaced, plc, indx, compliant)
-	}
-	// We want resources and we found some that don't match what we want
-	if !mustNotHave && numNonCompliant > 0 {
-		//noncompliant; musthave and some objects do not exist
-		update = createMustHaveStatus("", kind, nonCompliantObjects, namespaced, plc, indx, compliant)
-	}
-	// We want no resources and none were found
-	if mustNotHave && numNonCompliant == 0 {
-		//compliant; mustnothave and no objects exist
-		compliant = true
-		update = createMustNotHaveStatus(kind, compliantObjects, namespaced, plc, indx, compliant)
-	}
+
 	if update {
 		//update parent policy with violation
 		eventType := eventNormal

--- a/pkg/controller/configurationpolicy/configurationpolicy_controller.go
+++ b/pkg/controller/configurationpolicy/configurationpolicy_controller.go
@@ -481,24 +481,29 @@ func createInformStatus(mustNotHave bool, numCompliant int, numNonCompliant int,
 	if kind == "" {
 		return
 	}
-	if !mustNotHave && numCompliant == 0 {
+	// We want resources to exist, but none were found
+	if !mustNotHave && numCompliant == 0 && numNonCompliant == 0 {
 		//noncompliant; musthave and objects do not exist
 		update = createMustHaveStatus(desiredName, kind, nonCompliantObjects, namespaced,
 			plc, indx, compliant)
 	}
+	// We want no resources, but some were found
 	if mustNotHave && numNonCompliant > 0 {
 		//noncompliant; mustnothave and objects exist
 		update = createMustNotHaveStatus(kind, nonCompliantObjects, namespaced, plc, indx, compliant)
 	}
+	// We want resources and we found them
 	if !mustNotHave && numCompliant > 0 && numNonCompliant == 0 {
 		//compliant; musthave and objects exist
 		compliant = true
 		update = createMustHaveStatus("", kind, compliantObjects, namespaced, plc, indx, compliant)
 	}
+	// We want resources and we found some that don't match what we want
 	if !mustNotHave && numNonCompliant > 0 {
 		//noncompliant; musthave and some objects do not exist
 		update = createMustHaveStatus("", kind, nonCompliantObjects, namespaced, plc, indx, compliant)
 	}
+	// We want no resources and none were found
 	if mustNotHave && numNonCompliant == 0 {
 		//compliant; mustnothave and no objects exist
 		compliant = true

--- a/pkg/controller/configurationpolicy/configurationpolicy_controller.go
+++ b/pkg/controller/configurationpolicy/configurationpolicy_controller.go
@@ -490,10 +490,14 @@ func createInformStatus(mustNotHave bool, numCompliant int, numNonCompliant int,
 		//noncompliant; mustnothave and objects exist
 		update = createMustNotHaveStatus(kind, nonCompliantObjects, namespaced, plc, indx, compliant)
 	}
-	if !mustNotHave && numCompliant > 0 {
+	if !mustNotHave && numCompliant > 0 && numNonCompliant == 0 {
 		//compliant; musthave and objects exist
 		compliant = true
 		update = createMustHaveStatus("", kind, compliantObjects, namespaced, plc, indx, compliant)
+	}
+	if !mustNotHave && numNonCompliant > 0 {
+		//noncompliant; musthave and some objects do not exist
+		update = createMustHaveStatus("", kind, nonCompliantObjects, namespaced, plc, indx, compliant)
 	}
 	if mustNotHave && numNonCompliant == 0 {
 		//compliant; mustnothave and no objects exist
@@ -506,7 +510,9 @@ func createInformStatus(mustNotHave bool, numCompliant int, numNonCompliant int,
 		if !compliant {
 			eventType = eventWarning
 		}
-		recorder.Event(plc, eventType, fmt.Sprintf(plcFmtStr, plc.GetName()), convertPolicyStatusToString(plc))
+		if recorder != nil {
+			recorder.Event(plc, eventType, fmt.Sprintf(plcFmtStr, plc.GetName()), convertPolicyStatusToString(plc))
+		}
 	}
 	return update
 }

--- a/pkg/controller/configurationpolicy/configurationpolicy_controller_test.go
+++ b/pkg/controller/configurationpolicy/configurationpolicy_controller_test.go
@@ -645,7 +645,8 @@ func TestCreateInformStatus(t *testing.T) {
 		"reason": "my reason",
 	}
 	numNonCompliant = 1
-	// Test 1 compliant and 1 noncompliant resource
+
+	// Test 1 compliant and 1 noncompliant resource  NOTE: This use case is the new behavior change!
 	createInformStatus(mustNotHave, numCompliant, numNonCompliant,
 		compliantObjects, nonCompliantObjects, policy, objData)
 	assert.True(t, policy.Status.CompliancyDetails[0].ComplianceState == policiesv1alpha1.NonCompliant)
@@ -657,6 +658,7 @@ func TestCreateInformStatus(t *testing.T) {
 	numCompliant = 2
 	numNonCompliant = 0
 	delete(nonCompliantObjects, "test2")
+
 	// Test 2 compliant resources
 	createInformStatus(mustNotHave, numCompliant, numNonCompliant,
 		compliantObjects, nonCompliantObjects, policy, objData)

--- a/pkg/controller/configurationpolicy/configurationpolicy_controller_test.go
+++ b/pkg/controller/configurationpolicy/configurationpolicy_controller_test.go
@@ -572,3 +572,93 @@ func newRuleTemplate(verbs, apiGroups, resources, nonResourceURLs string, compli
 		},
 	}
 }
+
+func TestCreateInformStatus(t *testing.T) {
+	policy := &policiesv1alpha1.ConfigurationPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo",
+			Namespace: "default",
+		},
+		Spec: policiesv1alpha1.ConfigurationPolicySpec{
+			Severity: "low",
+			NamespaceSelector: policiesv1alpha1.Target{
+				Include: []string{"test1", "test2"},
+			},
+			RemediationAction: "inform",
+			ObjectTemplates: []*policiesv1alpha1.ObjectTemplate{
+				&policiesv1alpha1.ObjectTemplate{
+					ComplianceType:   "musthave",
+					ObjectDefinition: runtime.RawExtension{},
+				},
+			},
+		},
+	}
+	objNamespaced := true
+	objData := map[string]interface{}{
+		"indx":        0,
+		"kind":        "Secret",
+		"desiredName": "myobject",
+		"namespaced":  objNamespaced,
+	}
+	mustNotHave := false
+	numCompliant := 0
+	numNonCompliant := 1
+	var nonCompliantObjects map[string]map[string]interface{} = make(map[string]map[string]interface{})
+	var compliantObjects map[string]map[string]interface{} = make(map[string]map[string]interface{})
+	nonCompliantObjects["test1"] = map[string]interface{}{
+		"names":  []string{"myobject"},
+		"reason": "my reason",
+	}
+
+	// Test 1 NonCompliant resource
+	createInformStatus(mustNotHave, numCompliant, numNonCompliant,
+		compliantObjects, nonCompliantObjects, policy, objData)
+	assert.True(t, policy.Status.CompliancyDetails[0].ComplianceState == policiesv1alpha1.NonCompliant)
+
+	nonCompliantObjects["test2"] = map[string]interface{}{
+		"names":  []string{"myobject"},
+		"reason": "my reason",
+	}
+	numNonCompliant = 2
+
+	// Test 2 NonCompliant resources
+	createInformStatus(mustNotHave, numCompliant, numNonCompliant,
+		compliantObjects, nonCompliantObjects, policy, objData)
+	assert.True(t, policy.Status.CompliancyDetails[0].ComplianceState == policiesv1alpha1.NonCompliant)
+
+	delete(nonCompliantObjects, "test1")
+	delete(nonCompliantObjects, "test2")
+
+	// Test 0 resources
+	numNonCompliant = 0
+	createInformStatus(mustNotHave, numCompliant, numNonCompliant,
+		compliantObjects, nonCompliantObjects, policy, objData)
+	assert.True(t, policy.Status.CompliancyDetails[0].ComplianceState == policiesv1alpha1.NonCompliant)
+
+	compliantObjects["test1"] = map[string]interface{}{
+		"names":  []string{"myobject"},
+		"reason": "my reason",
+	}
+	numCompliant = 1
+	nonCompliantObjects["test2"] = map[string]interface{}{
+		"names":  []string{"myobject"},
+		"reason": "my reason",
+	}
+	numNonCompliant = 1
+	// Test 1 compliant and 1 noncompliant resource
+	createInformStatus(mustNotHave, numCompliant, numNonCompliant,
+		compliantObjects, nonCompliantObjects, policy, objData)
+	assert.True(t, policy.Status.CompliancyDetails[0].ComplianceState == policiesv1alpha1.NonCompliant)
+
+	compliantObjects["test2"] = map[string]interface{}{
+		"names":  []string{"myobject"},
+		"reason": "my reason",
+	}
+	numCompliant = 2
+	numNonCompliant = 0
+	delete(nonCompliantObjects, "test2")
+	// Test 2 compliant resources
+	createInformStatus(mustNotHave, numCompliant, numNonCompliant,
+		compliantObjects, nonCompliantObjects, policy, objData)
+	assert.True(t, policy.Status.CompliancyDetails[0].ComplianceState == policiesv1alpha1.Compliant)
+}


### PR DESCRIPTION
Signed-off-by: Gus Parvin <gparvin@redhat.com>
When using an `inform` policy that `musthave` a certain resource, the compliance should be based off the evaluation results coming from each namespace where the policy is applied/selected.  Instead of one compliant namespace making the policy Compliant, each selected namespace must be compliant to make the policy compliant.