### PR TITLE
clean up code

### DIFF
--- a/pkg/controller/configurationpolicy/configurationpolicy_controller.go
+++ b/pkg/controller/configurationpolicy/configurationpolicy_controller.go
@@ -1173,7 +1173,8 @@ func deleteObject(namespaced bool, namespace string, name string, rsrc schema.Gr
 	return deleted, err
 }
 
-//TODO check whether this function can be removed
+//mergeSpecs is a wrapper for the recursive function to merge 2 maps. It marshals the objects into JSON
+//to make sure they are valid objects before calling the merge function
 func mergeSpecs(templateVal, existingVal interface{}, ctype string) (interface{}, error) {
 	data1, err := json.Marshal(templateVal)
 	if err != nil {

--- a/pkg/controller/configurationpolicy/configurationpolicy_controller.go
+++ b/pkg/controller/configurationpolicy/configurationpolicy_controller.go
@@ -1238,7 +1238,10 @@ func mergeSpecsHelper(templateVal, existingVal interface{}, ctype string) interf
 			}
 			return templateVal
 		}
-		//TODO add case for existing being smaller here, return template
+		//if existing value is shorter than the template value, no merge needed since it will always be a mismatch
+		if len(existingVal) < len(templateVal) {
+			return templateVal
+		}
 		if len(existingVal) > 0 {
 			//if there are an equal amount of maps in the template and existing list, recurse on each one to merge the
 			//extra data from the existing object in

--- a/pkg/controller/configurationpolicy/configurationpolicy_controller.go
+++ b/pkg/controller/configurationpolicy/configurationpolicy_controller.go
@@ -1196,7 +1196,6 @@ func mergeSpecs(templateVal, existingVal interface{}, ctype string) (interface{}
 	return mergeSpecsHelper(j1, j2, ctype), nil
 }
 
-
 // mergeSpecsHelper is a helper function that takes an object from the existing object and merges in all the data that is
 // different in the template. This way, comparing the merged object to the one that exists on the cluster will tell
 // you whether the existing object is compliant with the template. This function uses recursion to check mismatches in
@@ -1227,7 +1226,7 @@ func mergeSpecsHelper(templateVal, existingVal interface{}, ctype string) interf
 		}
 		existingVal, ok := existingVal.([]interface{})
 		if !ok {
-			//if one field is a list and the other isn't, don't bother merging 
+			//if one field is a list and the other isn't, don't bother merging
 			return templateVal
 		}
 		if len(existingVal) > len(templateVal) {

--- a/pkg/controller/configurationpolicy/configurationpolicy_utils.go
+++ b/pkg/controller/configurationpolicy/configurationpolicy_utils.go
@@ -165,13 +165,6 @@ func checkListFieldsWithSort(mergedObj []map[string]interface{}, oldObj []map[st
 					match = false
 					break
 				}
-				//TODO check if this sort is necessary
-				sort.Slice(oVal, func(i, j int) bool {
-					return fmt.Sprintf("%v", oVal[i]) < fmt.Sprintf("%v", oVal[j])
-				})
-				sort.Slice(mVal, func(x, y int) bool {
-					return fmt.Sprintf("%v", mVal[x]) < fmt.Sprintf("%v", mVal[y])
-				})
 				if len(mVal) != len(oVal) {
 					match = false
 				} else {

--- a/pkg/controller/configurationpolicy/configurationpolicy_utils.go
+++ b/pkg/controller/configurationpolicy/configurationpolicy_utils.go
@@ -124,13 +124,6 @@ func checkFieldsWithSort(mergedObj map[string]interface{}, oldObj map[string]int
 				match = false
 				break
 			}
-			//TODO see if this sort is necessary
-			sort.Slice(oVal, func(i, j int) bool {
-				return fmt.Sprintf("%v", oVal[i]) < fmt.Sprintf("%v", oVal[j])
-			})
-			sort.Slice(mVal, func(x, y int) bool {
-				return fmt.Sprintf("%v", mVal[x]) < fmt.Sprintf("%v", mVal[y])
-			})
 			if len(mVal) != len(oVal) {
 				match = false
 			} else {

--- a/pkg/controller/configurationpolicy/configurationpolicy_utils.go
+++ b/pkg/controller/configurationpolicy/configurationpolicy_utils.go
@@ -69,6 +69,8 @@ func updateRelatedObjectsStatus(list []policyv1.RelatedObject,
 	return list
 }
 
+//equalObjWithSort is a wrapper function that calls the correct function to check equality depending on what
+//type the objects to compare are
 func equalObjWithSort(mergedObj interface{}, oldObj interface{}) (areEqual bool) {
 	switch mergedObj := mergedObj.(type) {
 	case (map[string]interface{}):
@@ -87,6 +89,8 @@ func equalObjWithSort(mergedObj interface{}, oldObj interface{}) (areEqual bool)
 	return true
 }
 
+//checFieldsWithSort is a check for maps that uses an arbitrary sort to ensure it is
+//comparing the right values
 func checkFieldsWithSort(mergedObj map[string]interface{}, oldObj map[string]interface{}) (matches bool) {
 	//needed to compare lists, since merge messes up the order
 	if len(mergedObj) < len(oldObj) {
@@ -96,6 +100,7 @@ func checkFieldsWithSort(mergedObj map[string]interface{}, oldObj map[string]int
 	for i, mVal := range mergedObj {
 		switch mVal := mVal.(type) {
 		case (map[string]interface{}):
+			//if field is a map, recurse to check for a match
 			oVal, ok := oldObj[i].(map[string]interface{})
 			if !ok {
 				match = false
@@ -104,6 +109,7 @@ func checkFieldsWithSort(mergedObj map[string]interface{}, oldObj map[string]int
 				match = false
 			}
 		case ([]map[string]interface{}):
+			//if field is a list of maps, use checkListFieldsWithSort to check for a match
 			oVal, ok := oldObj[i].([]map[string]interface{})
 			if !ok {
 				match = false
@@ -112,11 +118,13 @@ func checkFieldsWithSort(mergedObj map[string]interface{}, oldObj map[string]int
 				match = false
 			}
 		case ([]interface{}):
+			//if field is a generic list, sort and iterate through them to make sure each value matches
 			oVal, ok := oldObj[i].([]interface{})
 			if !ok {
 				match = false
 				break
 			}
+			//TODO see if this sort is necessary
 			sort.Slice(oVal, func(i, j int) bool {
 				return fmt.Sprintf("%v", oVal[i]) < fmt.Sprintf("%v", oVal[j])
 			})
@@ -131,6 +139,7 @@ func checkFieldsWithSort(mergedObj map[string]interface{}, oldObj map[string]int
 				}
 			}
 		default:
+			//if field is not an object, just do a basic compare to check for a match
 			oVal := oldObj[i]
 			if fmt.Sprint(oVal) != fmt.Sprint(mVal) {
 				match = false
@@ -139,7 +148,8 @@ func checkFieldsWithSort(mergedObj map[string]interface{}, oldObj map[string]int
 	}
 	return match
 }
-
+//checkListFieldsWithSort is a check for lists of maps that uses an arbitrary sort to ensure it is
+//comparing the right values
 func checkListFieldsWithSort(mergedObj []map[string]interface{}, oldObj []map[string]interface{}) (matches bool) {
 	sort.Slice(oldObj, func(i, j int) bool {
 		return fmt.Sprintf("%v", oldObj[i]) < fmt.Sprintf("%v", oldObj[j])
@@ -155,11 +165,13 @@ func checkListFieldsWithSort(mergedObj []map[string]interface{}, oldObj []map[st
 		for i, mVal := range mergedItem {
 			switch mVal := mVal.(type) {
 			case ([]interface{}):
+				//if a map in the list contains a nested list, sort and check for equality
 				oVal, ok := oldItem[i].([]interface{})
 				if !ok {
 					match = false
 					break
 				}
+				//TODO check if this sort is necessary
 				sort.Slice(oVal, func(i, j int) bool {
 					return fmt.Sprintf("%v", oVal[i]) < fmt.Sprintf("%v", oVal[j])
 				})
@@ -174,10 +186,12 @@ func checkListFieldsWithSort(mergedObj []map[string]interface{}, oldObj []map[st
 					}
 				}
 			case (map[string]interface{}):
+				//if a map in the list contains another map, check fields for equality
 				if !checkFieldsWithSort(mVal, oldItem[i].(map[string]interface{})) {
 					match = false
 				}
 			default:
+				//if the field in the map is not an object, just do a generic check
 				oVal := oldItem[i]
 				if fmt.Sprint(oVal) != fmt.Sprint(mVal) {
 					match = false
@@ -188,6 +202,7 @@ func checkListFieldsWithSort(mergedObj []map[string]interface{}, oldObj []map[st
 	return match
 }
 
+//checkListsMatch is a generic list check that uses an arbitrary sort to ensure it is comparing the right values
 func checkListsMatch(oldVal []interface{}, mergedVal []interface{}) (m bool) {
 	oVal := append([]interface{}{}, oldVal...)
 	mVal := append([]interface{}{}, mergedVal...)
@@ -207,10 +222,12 @@ func checkListsMatch(oldVal []interface{}, mergedVal []interface{}) (m bool) {
 	for idx, oNestedVal := range oVal {
 		switch oNestedVal := oNestedVal.(type) {
 		case (map[string]interface{}):
+			//if list contains maps, recurse on those maps to check for a match
 			if !checkFieldsWithSort(mVal[idx].(map[string]interface{}), oNestedVal) {
 				match = false
 			}
 		default:
+			//otherwise, just do a generic check
 			if fmt.Sprint(oNestedVal) != fmt.Sprint(mVal[idx]) {
 				match = false
 			}

--- a/pkg/controller/configurationpolicy/configurationpolicy_utils.go
+++ b/pkg/controller/configurationpolicy/configurationpolicy_utils.go
@@ -148,6 +148,7 @@ func checkFieldsWithSort(mergedObj map[string]interface{}, oldObj map[string]int
 	}
 	return match
 }
+
 //checkListFieldsWithSort is a check for lists of maps that uses an arbitrary sort to ensure it is
 //comparing the right values
 func checkListFieldsWithSort(mergedObj []map[string]interface{}, oldObj []map[string]interface{}) (matches bool) {


### PR DESCRIPTION
During the 2.3 retrospective, we talked about the health of the GRC codebase not being as good as it could be. As the configuration policy controller is one of the more confusing and less documented repos GRC manages, this PR:
- adds comments
- renames some variables for clarity
- removes some dead code