### PR TITLE
edit comment in merge specs to reflect new behavior

### DIFF
--- a/pkg/controller/configurationpolicy/configurationpolicy_controller.go
+++ b/pkg/controller/configurationpolicy/configurationpolicy_controller.go
@@ -1231,8 +1231,8 @@ func mergeSpecsHelper(templateVal, existingVal interface{}, ctype string) interf
 			return templateVal
 		}
 		if len(existingVal) > 0 {
-			//if there are more values in the existing object than the template and our complianceType is musthave,
-			//we need to merge in the extra data in the existing object to do a proper compare
+			//if both values are non-empty lists, we need to merge in the extra data in the existing
+			//object to do a proper compare
 			return mergeArrays(templateVal, existingVal, ctype)
 		}
 	case nil:


### PR DESCRIPTION
Signed-off-by: Will Kutler <wkutler@redhat.com>

fixes comments in the merge function to reflect its new behavior after https://github.com/open-cluster-management/config-policy-controller/commit/8f5d4c19e4c65cdaf6a31e4a1f142f841e7f4631