### PR TITLE
Whitespace in lists

### DIFF
--- a/pkg/controller/configurationpolicy/configurationpolicy_controller.go
+++ b/pkg/controller/configurationpolicy/configurationpolicy_controller.go
@@ -1246,8 +1246,7 @@ func mergeSpecsHelper(templateVal, existingVal interface{}, ctype string) interf
 	if !ok {
 		return templateVal
 	}
-	//if value is a string, trim whitespace on it to avoid issues with compare
-	return strings.TrimSpace(templateVal.(string))
+	return templateVal.(string)
 }
 
 // isSorted is a helper function that checks whether an array is sorted

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -49,6 +49,7 @@ var (
 	gvrSecret             schema.GroupVersionResource
 	gvrClusterClaim       schema.GroupVersionResource
 	gvrConfigMap          schema.GroupVersionResource
+	gvrDeployment         schema.GroupVersionResource
 
 	defaultImageRegistry string
 )
@@ -75,6 +76,7 @@ var _ = BeforeSuite(func() {
 	gvrSCC = schema.GroupVersionResource{Group: "security.openshift.io", Version: "v1", Resource: "securitycontextconstraints"}
 	gvrSecret = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "secrets"}
 	gvrClusterClaim = schema.GroupVersionResource{Group: "cluster.open-cluster-management.io", Version: "v1alpha1", Resource: "clusterclaims"}
+	gvrDeployment = schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
 	clientManaged = NewKubeClient("", kubeconfigManaged, "")
 	clientManagedDynamic = NewKubeClientDynamic("", kubeconfigManaged, "")
 	defaultImageRegistry = "quay.io/open-cluster-management"

--- a/test/resources/case12_list_compare/case12_whitespace_create.yaml
+++ b/test/resources/case12_list_compare/case12_whitespace_create.yaml
@@ -1,0 +1,34 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: ConfigurationPolicy
+metadata:
+  name: policy-pod-whitespace-env
+spec:
+  remediationAction: enforce
+  namespaceSelector:
+    exclude: ["kube-*"]
+    include: ["default"]
+  object-templates:
+    - complianceType: musthave
+      objectDefinition:
+        apiVersion: apps/v1
+        kind: Deployment
+        metadata:
+          name: envvar-whitespace
+          labels:
+            test: envvar-whitespace
+        spec:
+          replicas: 0
+          selector:
+            matchLabels:
+              test: envvar-whitespace
+          template:
+            metadata:
+              labels:
+                test: envvar-whitespace
+            spec:
+              containers:
+                - image: nginx:1.7.9
+                  name: nginx
+                  env:
+                    - name: DEMO_GREETING
+                      value: " \t hello with tricky whitespace \n "


### PR DESCRIPTION
When merging lists, it was trimming whitespace from some of the items. In cases where a resource has a string in a list, this caused the controller to append a duplicate of the item every time it enforced the configuration. This issue recently appeared in framework tests from a gatekeeper resource (with a string ending in a newline) that was being created.

Previously, the issue would not appear as often, because if the cluster resource's list had 1 item, and the policy template's list had 1 item, the template would overwrite the cluster configuration. That behavior was recently changed so that if the "new" item and "old" item don't match, the new item is appended to the list. (Note - previous behavior of overwriting the list can still be accomplished through `mustonlyhave` policies).