### PR TITLE
Use the latest templates API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/onsi/ginkgo v1.14.1
 	github.com/onsi/gomega v1.10.2
 	github.com/open-cluster-management/addon-framework v0.0.0-20210621074027-a81f712c10c2
-	github.com/open-cluster-management/go-template-utils v0.0.0-20210727143025-1d10434a6eb7
+	github.com/open-cluster-management/go-template-utils v1.0.0
 	github.com/operator-framework/operator-sdk v0.19.4
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -701,8 +701,8 @@ github.com/open-cluster-management/addon-framework v0.0.0-20210621074027-a81f712
 github.com/open-cluster-management/addon-framework v0.0.0-20210621074027-a81f712c10c2/go.mod h1:mcpd6pc0j/L+WLFwV2MXHVMr+86ri2iUdTK2M8RHJ7U=
 github.com/open-cluster-management/api v0.0.0-20210409125704-06f2aec1a73f h1:s6z3k0jV0ccoYDPJWMSqVNevO1UoQLYb8f7dYFALSNk=
 github.com/open-cluster-management/api v0.0.0-20210409125704-06f2aec1a73f/go.mod h1:ot+A1DWq+v1IV+e1S7nhIteYAmNByFgtazvzpoeAfRQ=
-github.com/open-cluster-management/go-template-utils v0.0.0-20210727143025-1d10434a6eb7 h1:7VDqMRX5H+vMtcRJFu7M0wYhIlyWmzP139C4ca7oVkk=
-github.com/open-cluster-management/go-template-utils v0.0.0-20210727143025-1d10434a6eb7/go.mod h1:AY1MHVmUtaLkM04w8uXFX8zPecl7Qn+u+3WUGeAuFf4=
+github.com/open-cluster-management/go-template-utils v1.0.0 h1:JwNUwiTrUM0GIqjCT26zvL6xFmXswhoH4EPc+SQOIxo=
+github.com/open-cluster-management/go-template-utils v1.0.0/go.mod h1:AY1MHVmUtaLkM04w8uXFX8zPecl7Qn+u+3WUGeAuFf4=
 github.com/opencontainers/go-digest v0.0.0-20170106003457-a6d0ee40d420/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/opencontainers/go-digest v0.0.0-20180430190053-c9281466c8b2/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=


### PR DESCRIPTION
This updates the dependency on the go-template-utils module.

This depends on https://github.com/open-cluster-management/go-template-utils/pull/7

Resolves https://github.com/open-cluster-management/backlog/issues/14952

Signed-off-by: mprahl <mprahl@users.noreply.github.com>