### PR TITLE
Fix an issue that caused integer comparison to fail

### DIFF
--- a/pkg/controller/configurationpolicy/configurationpolicy_controller.go
+++ b/pkg/controller/configurationpolicy/configurationpolicy_controller.go
@@ -5,7 +5,6 @@ package configurationpolicy
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"reflect"
 	"sort"
@@ -25,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/json"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"

--- a/pkg/controller/configurationpolicy/configurationpolicy_controller_test.go
+++ b/pkg/controller/configurationpolicy/configurationpolicy_controller_test.go
@@ -232,15 +232,21 @@ func TestCompareSpecs(t *testing.T) {
 	}
 	assert.Equal(t, reflect.DeepEqual(merged, mergedExpected), true)
 	spec1 = map[string]interface{}{
-		"containers": map[string]string{
+		"containers": map[string]interface{}{
 			"image": "nginx1.7.9",
 			"test":  "1111",
+			"timestamp": map[string]int64{
+				"seconds": 1631796491,
+			},
 		},
 	}
 	spec2 = map[string]interface{}{
-		"containers": map[string]string{
+		"containers": map[string]interface{}{
 			"image": "nginx1.7.9",
 			"name":  "nginx",
+			"timestamp": map[string]int64{
+				"seconds": 1631796491,
+			},
 		},
 	}
 	merged, err = compareSpecs(spec1, spec2, "musthave")
@@ -248,10 +254,16 @@ func TestCompareSpecs(t *testing.T) {
 		t.Fatalf("compareSpecs: (%v)", err)
 	}
 	mergedExpected = map[string]interface{}{
-		"containers": map[string]string{
+		"containers": map[string]interface{}{
 			"image": "nginx1.7.9",
 			"name":  "nginx",
 			"test":  "1111",
+			// This verifies that the type of the number has not changed as part of compare specs.
+			// With standard JSON marshaling and unmarshaling, it will cause an int64 to be
+			// converted to a float64. This ensures this does not happen.
+			"timestamp": map[string]int64{
+				"seconds": 1631796491,
+			},
 		},
 	}
 	assert.Equal(t, reflect.DeepEqual(fmt.Sprint(merged), fmt.Sprint(mergedExpected)), true)


### PR DESCRIPTION
This fixes the situation where the controller is comparing what is in
the policy versus what already exists, and the object being compared
contains an integer.

The code in the mergeSpecs function marshals and unmarshals the existing
object and the object in the policy. Presumably this is to create a copy
of the objects before modification. By doing so with the encoding/json
package, it converts any integers to float64.

This caused an issue in the checkFieldsWithSort function which compared
the existing object with the merged object, since the existing object
referenced here did not go through the marshal and unmarshal process,
but the merged object did. This meant that the integers in the merged
object were of type float64, but they remained integers in the existing
object. When checkFieldsWithSort converts both integers to strings to
compare, if the one of type float64 is a large enough number, it gets
printed in scientific notation where as the one that remained of type
integer does not. This would cause a mismatch even though it should have
matched.

The solution is quite simple. Just start using the json package from
Kubernetes so that the same unmarshaling process occurs in all cases.