### PR TITLE
Update go-template-utils to v1.2.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/onsi/ginkgo v1.14.1
 	github.com/onsi/gomega v1.10.2
 	github.com/open-cluster-management/addon-framework v0.0.0-20210621074027-a81f712c10c2
-	github.com/open-cluster-management/go-template-utils v1.1.0
+	github.com/open-cluster-management/go-template-utils v1.2.1
 	github.com/operator-framework/operator-sdk v0.19.4
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -703,6 +703,8 @@ github.com/open-cluster-management/api v0.0.0-20210409125704-06f2aec1a73f h1:s6z
 github.com/open-cluster-management/api v0.0.0-20210409125704-06f2aec1a73f/go.mod h1:ot+A1DWq+v1IV+e1S7nhIteYAmNByFgtazvzpoeAfRQ=
 github.com/open-cluster-management/go-template-utils v1.1.0 h1:IwHWYTDSYgegNfOsdRi+19a4B9P0Lu4+os6v7rXk0t8=
 github.com/open-cluster-management/go-template-utils v1.1.0/go.mod h1:+D8buOYN/VMVuTEd8WnnJQn+Z1oU4sT2OXbYZE+mIDk=
+github.com/open-cluster-management/go-template-utils v1.2.1 h1:12vHGg835BzYC08zndblbW5QOvPgNQo94jsigWyzb2o=
+github.com/open-cluster-management/go-template-utils v1.2.1/go.mod h1:+D8buOYN/VMVuTEd8WnnJQn+Z1oU4sT2OXbYZE+mIDk=
 github.com/opencontainers/go-digest v0.0.0-20170106003457-a6d0ee40d420/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/opencontainers/go-digest v0.0.0-20180430190053-c9281466c8b2/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=


### PR DESCRIPTION
This makes the code consistent with the policy propagator in:
https://github.com/open-cluster-management/governance-policy-propagator/pull/101