### PR TITLE
Protect the policy cache from unintended updates

### DIFF
--- a/pkg/controller/configurationpolicy/configurationpolicy_controller.go
+++ b/pkg/controller/configurationpolicy/configurationpolicy_controller.go
@@ -220,6 +220,11 @@ func PeriodicallyExecConfigPolicies(freq uint, test bool) {
 			//flattenedpolicylist only contains 1 of each policy instance
 			for _, policy := range flattenedPolicyList {
 				Mx.Lock()
+				// Deep copy the policy since even though handleObjectTemplates accepts a copy
+				// (i.e. not a pointer) of the policy, policy.Spec.ObjectTemplates is a slice of
+				// pointers, so any modifications to the objects in that slice will be reflected in
+				// the PolicyMap cache, which can have unintended side effects.
+				policy = (*policy).DeepCopy()
 				//handle each template in each policy
 				handleObjectTemplates(*policy, apiresourcelist, apigroups)
 				Mx.Unlock()

--- a/test/resources/case13_templatization/case13_update_referenced_object.yaml
+++ b/test/resources/case13_templatization/case13_update_referenced_object.yaml
@@ -1,0 +1,20 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: ConfigurationPolicy
+metadata:
+  name: policy-update-referenced-object
+spec:
+  remediationAction: enforce
+  namespaceSelector:
+    exclude: ["kube-*"]
+    include: ["default"]
+  object-templates:
+    - complianceType: musthave
+      objectDefinition:
+        apiVersion: v1
+        kind: ConfigMap
+        metadata:
+          name: configmap-update-referenced-object-repl
+          namespace: default
+        data:
+          message: |
+            {{ fromConfigMap "default" "configmap-update-referenced-object" "message" }}


### PR DESCRIPTION
Deep copy the policy before passing it to handleObjectTemplates since even
though handleObjectTemplates accepts a copy (i.e. not a pointer) of the
policy, policy.Spec.ObjectTemplates is a slice of pointers, so any
modifications to the objects in that slice will be reflected in
the PolicyMap cache, which can have unintended side effects.

This manifested itself when a policy has templates which when resolved,
still have intentional template delimiters (i.e. {{ and }}) in the result.
On the first time being processed, everything would go well. On the
second or third time, when the policy cache was not updated again by the
reconciler, the policy in the cache already had resolved templates. This
would lead to the templates code trying to reprocess the already
resolved policy.

Additionally to this, this caused some updates to referenced resource
objects in templates to not get properly updated in the policy.

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2007575