### PR TITLE
Annotation to Disable Template Processing

### DIFF
--- a/pkg/controller/configurationpolicy/configurationpolicy_controller.go
+++ b/pkg/controller/configurationpolicy/configurationpolicy_controller.go
@@ -311,7 +311,7 @@ func handleObjectTemplates(plc policyv1.ConfigurationPolicy, apiresourcelist []*
 			} else {
 				disableTemplates = bool_disableAnnotation
 			}
-		}
+		}//end disableannotation
 
 		if !disableTemplates {
 

--- a/pkg/controller/configurationpolicy/configurationpolicy_controller.go
+++ b/pkg/controller/configurationpolicy/configurationpolicy_controller.go
@@ -298,7 +298,6 @@ func handleObjectTemplates(plc policyv1.ConfigurationPolicy, apiresourcelist []*
 		// Here appears to be a  good place to hook in template processing
 		// This is at the head of objectemplate processing
 		// ( just before the perNamespace handling of objectDefinitions)
-
 		//if disable-templates annotations exists and is true, then do not process templates
 		annotations := plc.GetAnnotations()
 		disableTemplates := false

--- a/pkg/controller/configurationpolicy/configurationpolicy_controller.go
+++ b/pkg/controller/configurationpolicy/configurationpolicy_controller.go
@@ -304,7 +304,6 @@ func handleObjectTemplates(plc policyv1.ConfigurationPolicy, apiresourcelist []*
 		disableTemplates := false
 		if disableAnnotation, ok := annotations["policy.open-cluster-management.io/disable-templates"]; ok {
 			glog.Info("Found disable-templates Annotation : %s", disableAnnotation)
-
 			bool_disableAnnotation, err := strconv.ParseBool(disableAnnotation)
 			if err != nil {
 				glog.Error("Error parsing value for annotation: disable-templates %v", err)

--- a/pkg/controller/configurationpolicy/configurationpolicy_controller.go
+++ b/pkg/controller/configurationpolicy/configurationpolicy_controller.go
@@ -313,8 +313,8 @@ func handleObjectTemplates(plc policyv1.ConfigurationPolicy, apiresourcelist []*
 				glog.Error("Error parsing value for annotation: disable-templates %v", err)
 			} else {
 				disableTemplates = bool_disableAnnotation
-			}//
-		}//
+			}
+		}
 		if !disableTemplates {
 
 			//first check to make sure there are no hub-templates with delimiter - {{hub

--- a/pkg/controller/configurationpolicy/configurationpolicy_controller.go
+++ b/pkg/controller/configurationpolicy/configurationpolicy_controller.go
@@ -308,8 +308,8 @@ func handleObjectTemplates(plc policyv1.ConfigurationPolicy, apiresourcelist []*
 				glog.Error("Error parsing value for annotation: disable-templates %v", err)
 			} else {
 				disableTemplates = bool_disableAnnotation
-			}//end err
-		}//end disableannotation
+			}
+		}
 
 		if !disableTemplates {
 

--- a/pkg/controller/configurationpolicy/configurationpolicy_controller.go
+++ b/pkg/controller/configurationpolicy/configurationpolicy_controller.go
@@ -313,8 +313,8 @@ func handleObjectTemplates(plc policyv1.ConfigurationPolicy, apiresourcelist []*
 				glog.Error("Error parsing value for annotation: disable-templates %v", err)
 			} else {
 				disableTemplates = bool_disableAnnotation
-			}
-		}
+			}//
+		}//
 		if !disableTemplates {
 
 			//first check to make sure there are no hub-templates with delimiter - {{hub
@@ -331,8 +331,8 @@ func handleObjectTemplates(plc policyv1.ConfigurationPolicy, apiresourcelist []*
 					hubTemplatesErrMsg = "Error occured while processing hub-templates, check the policy events for more details."
 				}
 
-				update := createViolation(&plc, 0, "Error processing hub templates", hubTemplatesErrMsg)
-				if update {
+				updateStatus := createViolation(&plc, 0, "Error processing hub templates", hubTemplatesErrMsg)
+				if updateStatus {
 					recorder.Event(&plc, eventWarning, fmt.Sprintf(plcFmtStr, plc.GetName()), convertPolicyStatusToString(&plc))
 					addForUpdate(&plc)
 				}

--- a/pkg/controller/configurationpolicy/configurationpolicy_controller.go
+++ b/pkg/controller/configurationpolicy/configurationpolicy_controller.go
@@ -310,7 +310,7 @@ func handleObjectTemplates(plc policyv1.ConfigurationPolicy, apiresourcelist []*
 				glog.Error("Error parsing value for annotation: disable-templates %v", err)
 			} else {
 				disableTemplates = bool_disableAnnotation
-			}
+			}//end err
 		}//end disableannotation
 
 		if !disableTemplates {

--- a/pkg/controller/configurationpolicy/configurationpolicy_controller.go
+++ b/pkg/controller/configurationpolicy/configurationpolicy_controller.go
@@ -310,7 +310,6 @@ func handleObjectTemplates(plc policyv1.ConfigurationPolicy, apiresourcelist []*
 				disableTemplates = bool_disableAnnotation
 			}//
 		}//
-
 		if !disableTemplates {
 
 			//first check to make sure there are no hub-templates with delimiter - {{hub

--- a/pkg/controller/configurationpolicy/configurationpolicy_controller.go
+++ b/pkg/controller/configurationpolicy/configurationpolicy_controller.go
@@ -308,8 +308,8 @@ func handleObjectTemplates(plc policyv1.ConfigurationPolicy, apiresourcelist []*
 				glog.Error("Error parsing value for annotation: disable-templates %v", err)
 			} else {
 				disableTemplates = bool_disableAnnotation
-			}
-		}
+			}//
+		}//
 
 		if !disableTemplates {
 

--- a/pkg/controller/configurationpolicy/configurationpolicy_controller.go
+++ b/pkg/controller/configurationpolicy/configurationpolicy_controller.go
@@ -298,6 +298,11 @@ func handleObjectTemplates(plc policyv1.ConfigurationPolicy, apiresourcelist []*
 		// Here appears to be a  good place to hook in template processing
 		// This is at the head of objectemplate processing
 		// ( just before the perNamespace handling of objectDefinitions)
+
+		// check here to determine if the object definition has a template
+		// and execute  template-processing only if  there is a template pattern "{{" in it
+		// to avoid unnecessary parsing when there is no template in the definition.
+
 		//if disable-templates annotations exists and is true, then do not process templates
 		annotations := plc.GetAnnotations()
 		disableTemplates := false
@@ -334,13 +339,10 @@ func handleObjectTemplates(plc policyv1.ConfigurationPolicy, apiresourcelist []*
 				return
 			}
 
-			// check here to determine if the object definition has a template
-			// and execute  template-processing only if  there is a template pattern "{{" in it
-			// to avoid unnecessary parsing when there is no template in the definition.
 			if templates.HasTemplate(objectT.ObjectDefinition.Raw, "") {
 				resolvedTemplate, tplErr := tmplResolver.ResolveTemplate(objectT.ObjectDefinition.Raw, nil)
 				if tplErr != nil {
-					update := createViolation(&plc, 0, "Error processing template", tplErr.Error())
+					update := createViolation(&plc, 0, "Error processing template", tplErr.Error())//
 					if update {
 						recorder.Event(&plc, eventWarning, fmt.Sprintf(plcFmtStr, plc.GetName()), convertPolicyStatusToString(&plc))
 						addForUpdate(&plc)

--- a/pkg/controller/configurationpolicy/configurationpolicy_controller.go
+++ b/pkg/controller/configurationpolicy/configurationpolicy_controller.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"reflect"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -294,40 +295,42 @@ func handleObjectTemplates(plc policyv1.ConfigurationPolicy, apiresourcelist []*
 		var unstruct unstructured.Unstructured
 		unstruct.Object = make(map[string]interface{})
 
+
 		// Here appears to be a  good place to hook in template processing
 		// This is at the head of objectemplate processing
 		// ( just before the perNamespace handling of objectDefinitions)
 
-		// check here to determine if the object definition has a template
-		// and execute  template-processing only if  there is a template pattern "{{" in it
-		// to avoid unnecessary parsing when there is no template in the definition.
+		//if disable-templates annotations exists and is true, then do not process templates
+		annotations := plc.GetAnnotations()
+		disableTemplates := false
+		if disableAnnotation, ok := annotations["policy.open-cluster-management.io/disable-templates"]; ok {
+			glog.Info("Found disable-templates Annotation : %s",  disableAnnotation)
 
-		//first check to make sure there are no hub-templates with delimiter - {{hub
-		//if they exists, it means the template resolution on the hub did not succeed.
-		if templates.HasTemplate(objectT.ObjectDefinition.Raw, "{{hub") {
-			glog.Error("Configuration Policy has hub-templates. Error occured while processing hub-templates on the Hub Cluster.")
-
-			//check to see there is an annotation set to the hub error msg,
-			//if not ,set a generic msg
-			annotations := plc.GetAnnotations()
-			hubTemplatesErrMsg, ok := annotations["policy.open-cluster-management.io/hub-templates-error"]
-			if !ok || hubTemplatesErrMsg == "" {
-				//set a generic msg
-				hubTemplatesErrMsg = "Error occured while processing hub-templates, check the policy events for more details."
+			bool_disableAnnotation, err := strconv.ParseBool(disableAnnotation)
+			if(err != nil){
+				glog.Error("Error parsing value for annotation: disable-templates %v", err)
+			}else{
+				disableTemplates = bool_disableAnnotation
 			}
-
-			update := createViolation(&plc, 0, "Error processing hub templates", hubTemplatesErrMsg)
-			if update {
-				recorder.Event(&plc, eventWarning, fmt.Sprintf(plcFmtStr, plc.GetName()), convertPolicyStatusToString(&plc))
-				addForUpdate(&plc)
-			}
-			return
 		}
 
-		if templates.HasTemplate(objectT.ObjectDefinition.Raw, "") {
-			resolvedTemplate, tplErr := tmplResolver.ResolveTemplate(objectT.ObjectDefinition.Raw, nil)
-			if tplErr != nil {
-				update := createViolation(&plc, 0, "Error processing template", tplErr.Error())
+		if !disableTemplates {
+
+			//first check to make sure there are no hub-templates with delimiter - {{hub
+			//if they exists, it means the template resolution on the hub did not succeed.
+			if templates.HasTemplate(objectT.ObjectDefinition.Raw, "{{hub") {
+				glog.Error("Configuration Policy has hub-templates. Error occured while processing hub-templates on the Hub Cluster.")
+
+				//check to see there is an annotation set to the hub error msg,
+				//if not ,set a generic msg
+
+				hubTemplatesErrMsg, ok := annotations["policy.open-cluster-management.io/hub-templates-error"]
+				if !ok || hubTemplatesErrMsg == "" {
+					//set a generic msg
+					hubTemplatesErrMsg = "Error occured while processing hub-templates, check the policy events for more details."
+				}
+
+				update := createViolation(&plc, 0, "Error processing hub templates", hubTemplatesErrMsg)
 				if update {
 					recorder.Event(&plc, eventWarning, fmt.Sprintf(plcFmtStr, plc.GetName()), convertPolicyStatusToString(&plc))
 					addForUpdate(&plc)
@@ -335,9 +338,27 @@ func handleObjectTemplates(plc policyv1.ConfigurationPolicy, apiresourcelist []*
 				return
 			}
 
-			// Set the resolved data for use in further processing
-			objectT.ObjectDefinition.Raw = []byte(resolvedTemplate)
+			// check here to determine if the object definition has a template
+			// and execute  template-processing only if  there is a template pattern "{{" in it
+			// to avoid unnecessary parsing when there is no template in the definition.
+			if templates.HasTemplate(objectT.ObjectDefinition.Raw, "") {
+				resolvedTemplate, tplErr := tmplResolver.ResolveTemplate(objectT.ObjectDefinition.Raw, nil)
+				if tplErr != nil {
+					update := createViolation(&plc, 0, "Error processing template", tplErr.Error())
+					if update {
+						recorder.Event(&plc, eventWarning, fmt.Sprintf(plcFmtStr, plc.GetName()), convertPolicyStatusToString(&plc))
+						addForUpdate(&plc)
+					}
+					return
+				}
+
+				// Set the resolved data for use in further processing
+				objectT.ObjectDefinition.Raw = []byte(resolvedTemplate)
+			}
+
 		}
+
+
 
 		var blob interface{}
 		if jsonErr := json.Unmarshal(objectT.ObjectDefinition.Raw, &blob); jsonErr != nil {

--- a/pkg/controller/configurationpolicy/configurationpolicy_controller.go
+++ b/pkg/controller/configurationpolicy/configurationpolicy_controller.go
@@ -295,7 +295,6 @@ func handleObjectTemplates(plc policyv1.ConfigurationPolicy, apiresourcelist []*
 		var unstruct unstructured.Unstructured
 		unstruct.Object = make(map[string]interface{})
 
-
 		// Here appears to be a  good place to hook in template processing
 		// This is at the head of objectemplate processing
 		// ( just before the perNamespace handling of objectDefinitions)
@@ -304,12 +303,12 @@ func handleObjectTemplates(plc policyv1.ConfigurationPolicy, apiresourcelist []*
 		annotations := plc.GetAnnotations()
 		disableTemplates := false
 		if disableAnnotation, ok := annotations["policy.open-cluster-management.io/disable-templates"]; ok {
-			glog.Info("Found disable-templates Annotation : %s",  disableAnnotation)
+			glog.Info("Found disable-templates Annotation : %s", disableAnnotation)
 
 			bool_disableAnnotation, err := strconv.ParseBool(disableAnnotation)
-			if(err != nil){
+			if err != nil {
 				glog.Error("Error parsing value for annotation: disable-templates %v", err)
-			}else{
+			} else {
 				disableTemplates = bool_disableAnnotation
 			}
 		}
@@ -357,8 +356,6 @@ func handleObjectTemplates(plc policyv1.ConfigurationPolicy, apiresourcelist []*
 			}
 
 		}
-
-
 
 		var blob interface{}
 		if jsonErr := json.Unmarshal(objectT.ObjectDefinition.Raw, &blob); jsonErr != nil {


### PR DESCRIPTION
Signed-off-by: ckandag <ckandaga@redhat.com>

https://github.com/open-cluster-management/backlog/issues/16674

Setting this annotation on the configuration policy template will prevent any template processing.
"policy.open-cluster-management.io/disable-templates" :  "true"
