### PR TITLE
Initialize reconciler event recorder

### DIFF
--- a/main.go
+++ b/main.go
@@ -125,8 +125,9 @@ func main() {
 	}
 
 	if err = (&controllers.ConfigurationPolicyReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		Client:   mgr.GetClient(),
+		Scheme:   mgr.GetScheme(),
+		Recorder: mgr.GetEventRecorderFor(controllers.ControllerName),
 	}).SetupWithManager(mgr); err != nil {
 		log.Error(err, "unable to create controller", "controller", "ConfigurationPolicy")
 		os.Exit(1)


### PR DESCRIPTION
Missed this when updating the operator-sdk.

Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>