### PR TITLE
Fix stale related resources after a template change

### DIFF
--- a/controllers/configurationpolicy_controller.go
+++ b/controllers/configurationpolicy_controller.go
@@ -327,7 +327,7 @@ func handleObjectTemplates(plc policyv1.ConfigurationPolicy, apiresourcelist []*
 				update := createViolation(&plc, 0, "Error processing hub templates", hubTemplatesErrMsg)
 				if update {
 					recorder.Event(&plc, eventWarning, fmt.Sprintf(plcFmtStr, plc.GetName()), convertPolicyStatusToString(&plc))
-					addForUpdate(&plc)
+					checkRelatedAndUpdate(update, plc, relatedObjects, oldRelated)
 				}
 				return
 			}
@@ -338,7 +338,7 @@ func handleObjectTemplates(plc policyv1.ConfigurationPolicy, apiresourcelist []*
 					update := createViolation(&plc, 0, "Error processing template", tplErr.Error()) //
 					if update {
 						recorder.Event(&plc, eventWarning, fmt.Sprintf(plcFmtStr, plc.GetName()), convertPolicyStatusToString(&plc))
-						addForUpdate(&plc)
+						checkRelatedAndUpdate(update, plc, relatedObjects, oldRelated)
 					}
 					return
 				}


### PR DESCRIPTION
The user had a working policy and introduced a hub template that
was invalid.  The change to the policy caused the related
resources to be carried forward from the working state.  The fix
clears the related resources for this error case.

Refs:
 - https://github.com/open-cluster-management/backlog/issues/17589

Signed-off-by: Gus Parvin <gparvin@redhat.com>