### PR TITLE
Correct lease name

### DIFF
--- a/main.go
+++ b/main.go
@@ -172,7 +172,7 @@ func main() {
 			log.Info("Starting lease controller to report status")
 			leaseUpdater := lease.NewLeaseUpdater(
 				generatedClient,
-				"policy-controller",
+				"config-policy-controller",
 				operatorNs,
 			)
 


### PR DESCRIPTION
The status-sync-controller is already creating/updating a lease called `policy-controller`. This is cause lease is being updated even when status-sync-controller is down.

This reverts https://github.com/open-cluster-management/config-policy-controller/pull/141

For https://github.com/open-cluster-management/backlog/issues/17607

Signed-off-by: Yu Cao <ycao@redhat.com>