### PR TITLE
add special equality check for quantities of bytes

### DIFF
--- a/test/resources/case12_list_compare/case12_byte_create.yaml
+++ b/test/resources/case12_list_compare/case12_byte_create.yaml
@@ -1,0 +1,141 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: ConfigurationPolicy
+metadata:
+  name: policy-byte-create
+spec:
+  object-templates:
+  - complianceType: musthave
+    objectDefinition:
+      apiVersion: apps/v1
+      kind: StatefulSet
+      metadata:
+        name: splunk-log-forwarder
+        namespace: default
+        labels:
+          app.kubernetes.io/component: intermediate-fluentd
+      spec:
+        replicas: 3
+        serviceName: splunk-log-forwarder-headless-service
+        updateStrategy:
+          type: RollingUpdate
+        selector:
+          matchLabels:
+            app: splunk-log-forwarder
+        template:
+          metadata:
+            labels:
+              app: splunk-log-forwarder
+          spec:
+            restartPolicy: Always
+            terminationGracePeriodSeconds: 30
+            containers:
+              - resources:
+                  limits:
+                    cpu: 500m
+                    memory: 1024Mi
+                  requests:
+                    cpu: 100m
+                    memory: 512Mi
+                terminationMessagePath: /dev/termination-log
+                name: splunk-log-forwarder
+                env:
+                  - name: NODE_NAME
+                    valueFrom:
+                      fieldRef:
+                        apiVersion: v1
+                        fieldPath: spec.nodeName
+                  - name: LOG_LEVEL
+                    valueFrom:
+                      configMapKeyRef:
+                        name: splunk-log-forwarder-fluentd-configuration
+                        key: fluentd-loglevel
+                  - name: SPLUNK_SOURCETYPE
+                    valueFrom:
+                      configMapKeyRef:
+                        name: splunk-log-forwarder-fluentd-configuration
+                        key: splunk-sourcetype
+                  - name: SPLUNK_SOURCE
+                    valueFrom:
+                      configMapKeyRef:
+                        name: splunk-log-forwarder-fluentd-configuration
+                        key: splunk-source
+                  - name: SPLUNK_PORT
+                    valueFrom:
+                      configMapKeyRef:
+                        name: splunk-log-forwarder-fluentd-configuration
+                        key: splunk-port
+                  - name: SPLUNK_PROTOCOL
+                    valueFrom:
+                      configMapKeyRef:
+                        name: splunk-log-forwarder-fluentd-configuration
+                        key: splunk-protocol
+                  - name: SPLUNK_INSECURE
+                    valueFrom:
+                      configMapKeyRef:
+                        name: splunk-log-forwarder-fluentd-configuration
+                        key: splunk-insecure
+                  - name: SPLUNK_HOST
+                    valueFrom:
+                      secretKeyRef:
+                        name: splunk-secret-data
+                        key: splunk-host
+                  - name: SPLUNK_TOKEN
+                    valueFrom:
+                      secretKeyRef:
+                        name: splunk-secret-data
+                        key: splunk-hec-token
+                  - name: SPLUNK_INDEX
+                    valueFrom:
+                      secretKeyRef:
+                        name: splunk-secret-data
+                        key: splunk-index-name
+                imagePullPolicy: Always
+                volumeMounts:
+                  - name: splunk-log-forwarding-configmap
+                    readOnly: true
+                    mountPath: /etc/fluent/
+                  - name: buffer
+                    mountPath: "/var/log/fluentd"
+                terminationMessagePolicy: File
+                image: registry.redhat.io/openshift-logging/fluentd-rhel8:latest
+                args:
+                  - fluentd
+                livenessProbe:
+                  tcpSocket:
+                    port: 24224
+                  periodSeconds: 5
+                  timeoutSeconds: 3
+                  initialDelaySeconds: 10
+                readinessProbe:
+                  tcpSocket:
+                    port: 24224
+                  periodSeconds: 3
+                  timeoutSeconds: 2
+                  initialDelaySeconds: 2
+                ports:
+                  - containerPort: 24224
+                    name: forwarder-tcp
+                    protocol: TCP
+                  - containerPort: 24224
+                    name: forwarder-udp
+                    protocol: UDP
+            serviceAccount: splunk-log-forwarder
+            nodeSelector:
+              node-role.kubernetes.io/infra: ''
+            tolerations:
+            - effect: NoSchedule
+              key: node-role.kubernetes.io/infra
+              operator: Exists
+            volumes:
+              - name: splunk-log-forwarding-configmap
+                configMap:
+                  name: splunk-log-forwarder-fluentd-configuration
+                  items:
+                    - key: td-agent.conf
+                      path: fluent.conf
+                  defaultMode: 420
+                  optional: true
+              - name: buffer
+                emptyDir: {}
+            dnsPolicy: ClusterFirst
+  remediationAction: enforce

--- a/test/resources/case12_list_compare/case12_byte_inform.yaml
+++ b/test/resources/case12_list_compare/case12_byte_inform.yaml
@@ -1,0 +1,141 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: ConfigurationPolicy
+metadata:
+  name: policy-byte-inform
+spec:
+  object-templates:
+  - complianceType: musthave
+    objectDefinition:
+      apiVersion: apps/v1
+      kind: StatefulSet
+      metadata:
+        name: splunk-log-forwarder
+        namespace: default
+        labels:
+          app.kubernetes.io/component: intermediate-fluentd
+      spec:
+        replicas: 3
+        serviceName: splunk-log-forwarder-headless-service
+        updateStrategy:
+          type: RollingUpdate
+        selector:
+          matchLabels:
+            app: splunk-log-forwarder
+        template:
+          metadata:
+            labels:
+              app: splunk-log-forwarder
+          spec:
+            restartPolicy: Always
+            terminationGracePeriodSeconds: 30
+            containers:
+              - resources:
+                  limits:
+                    cpu: 500m
+                    memory: 1024Mi
+                  requests:
+                    cpu: 100m
+                    memory: 512Mi
+                terminationMessagePath: /dev/termination-log
+                name: splunk-log-forwarder
+                env:
+                  - name: NODE_NAME
+                    valueFrom:
+                      fieldRef:
+                        apiVersion: v1
+                        fieldPath: spec.nodeName
+                  - name: LOG_LEVEL
+                    valueFrom:
+                      configMapKeyRef:
+                        name: splunk-log-forwarder-fluentd-configuration
+                        key: fluentd-loglevel
+                  - name: SPLUNK_SOURCETYPE
+                    valueFrom:
+                      configMapKeyRef:
+                        name: splunk-log-forwarder-fluentd-configuration
+                        key: splunk-sourcetype
+                  - name: SPLUNK_SOURCE
+                    valueFrom:
+                      configMapKeyRef:
+                        name: splunk-log-forwarder-fluentd-configuration
+                        key: splunk-source
+                  - name: SPLUNK_PORT
+                    valueFrom:
+                      configMapKeyRef:
+                        name: splunk-log-forwarder-fluentd-configuration
+                        key: splunk-port
+                  - name: SPLUNK_PROTOCOL
+                    valueFrom:
+                      configMapKeyRef:
+                        name: splunk-log-forwarder-fluentd-configuration
+                        key: splunk-protocol
+                  - name: SPLUNK_INSECURE
+                    valueFrom:
+                      configMapKeyRef:
+                        name: splunk-log-forwarder-fluentd-configuration
+                        key: splunk-insecure
+                  - name: SPLUNK_HOST
+                    valueFrom:
+                      secretKeyRef:
+                        name: splunk-secret-data
+                        key: splunk-host
+                  - name: SPLUNK_TOKEN
+                    valueFrom:
+                      secretKeyRef:
+                        name: splunk-secret-data
+                        key: splunk-hec-token
+                  - name: SPLUNK_INDEX
+                    valueFrom:
+                      secretKeyRef:
+                        name: splunk-secret-data
+                        key: splunk-index-name
+                imagePullPolicy: Always
+                volumeMounts:
+                  - name: splunk-log-forwarding-configmap
+                    readOnly: true
+                    mountPath: /etc/fluent/
+                  - name: buffer
+                    mountPath: "/var/log/fluentd"
+                terminationMessagePolicy: File
+                image: registry.redhat.io/openshift-logging/fluentd-rhel8:latest
+                args:
+                  - fluentd
+                livenessProbe:
+                  tcpSocket:
+                    port: 24224
+                  periodSeconds: 5
+                  timeoutSeconds: 3
+                  initialDelaySeconds: 10
+                readinessProbe:
+                  tcpSocket:
+                    port: 24224
+                  periodSeconds: 3
+                  timeoutSeconds: 2
+                  initialDelaySeconds: 2
+                ports:
+                  - containerPort: 24224
+                    name: forwarder-tcp
+                    protocol: TCP
+                  - containerPort: 24224
+                    name: forwarder-udp
+                    protocol: UDP
+            serviceAccount: splunk-log-forwarder
+            nodeSelector:
+              node-role.kubernetes.io/infra: ''
+            tolerations:
+            - effect: NoSchedule
+              key: node-role.kubernetes.io/infra
+              operator: Exists
+            volumes:
+              - name: splunk-log-forwarding-configmap
+                configMap:
+                  name: splunk-log-forwarder-fluentd-configuration
+                  items:
+                    - key: td-agent.conf
+                      path: fluent.conf
+                  defaultMode: 420
+                  optional: true
+              - name: buffer
+                emptyDir: {}
+            dnsPolicy: ClusterFirst
+  remediationAction: inform


### PR DESCRIPTION
Signed-off-by: Will Kutler <wkutler@redhat.com>

Fixes a rare issue where if an object contained a quantity of bytes (ex: a `memory` field) that was too large, it would appear as a rounded string in the existing object and not in the template (ex: `1Gi` in the existing object and `1024Mi` in the template). This would incorrectly be flagged as a mismatch, causing issues like https://github.com/open-cluster-management/backlog/issues/17508 .