### PR TITLE
Support Annotation to disable go-template processing

### DIFF
--- a/pkg/controller/configurationpolicy/configurationpolicy_controller.go
+++ b/pkg/controller/configurationpolicy/configurationpolicy_controller.go
@@ -9,6 +9,7 @@ import (
 	"reflect"
 	"sort"
 	"strings"
+	"strconv"
 	"sync"
 	"time"
 
@@ -303,7 +304,20 @@ func handleObjectTemplates(plc policyv1.ConfigurationPolicy, apiresourcelist []*
 		// and execute  template-processing only if  there is a template pattern "{{" in it
 		// to avoid unnecessary parsing when there is no template in the definition.
 
-		if templates.HasTemplate(string(ext.Raw)) {
+		// if disable-templates annotations exists and is true, then do not process templates
+		annotations := plc.GetAnnotations()
+		disableTemplates := false
+		if disableAnnotation, ok := annotations["policy.open-cluster-management.io/disable-templates"]; ok {
+			glog.Infof("Found disable-templates Annotation : %s", disableAnnotation)
+			bool_disableAnnotation, err := strconv.ParseBool(disableAnnotation)
+			if err != nil {
+				glog.Errorf("Error parsing value for annotation: disable-templates %v", err)
+			} else {
+				disableTemplates = bool_disableAnnotation
+			} //
+		} //
+
+		if !disableTemplates && templates.HasTemplate(string(ext.Raw)) {
 			resolvedblob, tplErr := templates.ResolveTemplate(blob)
 			if tplErr != nil {
 				update := createViolation(&plc, 0, "Error processing template", tplErr.Error())

--- a/pkg/controller/configurationpolicy/configurationpolicy_controller.go
+++ b/pkg/controller/configurationpolicy/configurationpolicy_controller.go
@@ -8,8 +8,8 @@ import (
 	"fmt"
 	"reflect"
 	"sort"
-	"strings"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 


### PR DESCRIPTION
Signed-off-by: ckandag <ckandaga@redhat.com>

Backporting fix for #16674 to release-2.3 to allow disabling a template processing through an annotation.
Unable to cherry-pick due to various changes in 2.4 that are not in 2.3.

issue# https://github.com/open-cluster-management/backlog/issues/16674