### PR TITLE
Add full Policy Spec to event format tests

### DIFF
--- a/test/resources/case15_event_format/case15_parent_alwayscompliant.yaml
+++ b/test/resources/case15_event_format/case15_parent_alwayscompliant.yaml
@@ -2,3 +2,24 @@ apiVersion: policy.open-cluster-management.io/v1
 kind: Policy
 metadata:
   name: parent-alwayscompliant
+spec:
+  remediationAction: inform
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: mnh-pod-alwayscompliant
+        spec:
+          remediationAction: inform
+          namespaceSelector:
+            exclude: ["kube-*"]
+            include: ["default"]
+          object-templates:
+            - complianceType: mustnothave
+              objectDefinition:
+                apiVersion: v1
+                kind: Pod
+                metadata:
+                  name: case15-alwayscompliant

--- a/test/resources/case15_event_format/case15_parent_becomescompliant.yaml
+++ b/test/resources/case15_event_format/case15_parent_becomescompliant.yaml
@@ -2,3 +2,30 @@ apiVersion: policy.open-cluster-management.io/v1
 kind: Policy
 metadata:
   name: parent-becomescompliant
+spec:
+  remediationAction: inform
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: mh-pod-becomescompliant
+        spec:
+          remediationAction: inform
+          namespaceSelector:
+            exclude: ["kube-*"]
+            include: ["default"]
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: v1
+                kind: Pod
+                metadata:
+                  name: case15-becomescompliant
+                spec:
+                  containers:
+                    - image: nginx:1.7.9
+                      name: nginx
+                      ports:
+                        - containerPort: 80

--- a/test/resources/case15_event_format/case15_parent_becomesnoncompliant.yaml
+++ b/test/resources/case15_event_format/case15_parent_becomesnoncompliant.yaml
@@ -2,3 +2,24 @@ apiVersion: policy.open-cluster-management.io/v1
 kind: Policy
 metadata:
   name: parent-becomesnoncompliant
+spec:
+  remediationAction: inform
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: mnh-pod-becomesnoncompliant
+        spec:
+          remediationAction: inform
+          namespaceSelector:
+            exclude: ["kube-*"]
+            include: ["default"]
+          object-templates:
+            - complianceType: mustnothave
+              objectDefinition:
+                apiVersion: v1
+                kind: Pod
+                metadata:
+                  name: case15-becomesnoncompliant

--- a/test/resources/case15_event_format/case15_parent_nevercompliant.yaml
+++ b/test/resources/case15_event_format/case15_parent_nevercompliant.yaml
@@ -2,3 +2,24 @@ apiVersion: policy.open-cluster-management.io/v1
 kind: Policy
 metadata:
   name: parent-nevercompliant
+spec:
+  remediationAction: inform
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: mh-pod-nevercompliant
+        spec:
+          remediationAction: inform
+          namespaceSelector:
+            exclude: ["kube-*"]
+            include: ["default"]
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: v1
+                kind: Pod
+                metadata:
+                  name: case15-nevercompliant


### PR DESCRIPTION
Previously, the Policy CRD we were using here did not have a spec field,
so these test resources did not need them. But now, since these Policies
are invalid, they are causing problems in the tests.

This makes the Policies for these tests fully valid.

Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>