### PR TITLE
Refactor cleanup

### DIFF
--- a/controllers/configurationpolicy_controller.go
+++ b/controllers/configurationpolicy_controller.go
@@ -34,7 +34,6 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"k8s.io/client-go/restmapper"
@@ -93,18 +92,12 @@ func (r *ConfigurationPolicyReconciler) SetupWithManager(mgr ctrl.Manager) error
 
 // Initialize to initialize some controller variables
 func Initialize(kubeconfig *rest.Config, clientset *kubernetes.Clientset,
-	kubeClient *kubernetes.Interface, mgr manager.Manager, namespace, eventParent string) {
-	InitializeClient(kubeClient)
-	PlcChan = make(chan *policyv1.ConfigurationPolicy, 100) //buffering up to 100 policies for update
-	NamespaceWatched = namespace
-	clientSet = clientset
-	EventOnParent = strings.ToLower(eventParent)
+	kubeClient *kubernetes.Interface, namespace, eventParent string) {
 	config = kubeconfig
-}
-
-//InitializeClient helper function to initialize kubeclient
-func InitializeClient(kubeClient *kubernetes.Interface) {
+	clientSet = clientset
 	KubeClient = kubeClient
+	NamespaceWatched = namespace
+	EventOnParent = strings.ToLower(eventParent)
 }
 
 // blank assignment to verify that ConfigurationPolicyReconciler implements reconcile.Reconciler

--- a/controllers/configurationpolicy_controller.go
+++ b/controllers/configurationpolicy_controller.go
@@ -50,8 +50,6 @@ var availablePolicies common.SyncedPolicyMap
 // PlcChan a channel used to pass policies ready for update
 var PlcChan chan *policyv1.ConfigurationPolicy
 
-var recorder record.EventRecorder
-
 var clientSet *kubernetes.Clientset
 
 var eventNormal = "Normal"
@@ -79,8 +77,6 @@ var MxUpdateMap sync.RWMutex
 // KubeClient a k8s client used for k8s native resources
 var KubeClient *kubernetes.Interface
 
-var reconcilingAgent *ConfigurationPolicyReconciler
-
 // NamespaceWatched defines which namespace we can watch for the GRC policies and ignore others
 var NamespaceWatched string
 
@@ -103,7 +99,6 @@ func Initialize(kubeconfig *rest.Config, clientset *kubernetes.Clientset,
 	NamespaceWatched = namespace
 	clientSet = clientset
 	EventOnParent = strings.ToLower(eventParent)
-	recorder, _ = common.CreateRecorder(*KubeClient, ControllerName)
 	config = kubeconfig
 }
 
@@ -137,9 +132,6 @@ func (r *ConfigurationPolicyReconciler) Reconcile(ctx context.Context, request c
 
 	// Fetch the ConfigurationPolicy instance
 	instance := &policyv1.ConfigurationPolicy{}
-	if reconcilingAgent == nil {
-		reconcilingAgent = r
-	}
 	err := r.Get(context.TODO(), request.NamespacedName, instance)
 	if err != nil {
 		if errors.IsNotFound(err) {
@@ -167,7 +159,7 @@ func (r *ConfigurationPolicyReconciler) Reconcile(ctx context.Context, request c
 
 // PeriodicallyExecConfigPolicies loops through all configurationpolicies in the target namespace and triggers
 // template handling for each one. This function drives all the work the configuration policy controller does.
-func PeriodicallyExecConfigPolicies(freq uint, test bool) {
+func (r *ConfigurationPolicyReconciler) PeriodicallyExecConfigPolicies(freq uint, test bool) {
 	cachedApiResourceList := []*metav1.APIResourceList{}
 	cachedApiGroupsList := []*restmapper.APIGroupResources{}
 	for {
@@ -221,7 +213,7 @@ func PeriodicallyExecConfigPolicies(freq uint, test bool) {
 				// the PolicyMap cache, which can have unintended side effects.
 				policy = (*policy).DeepCopy()
 				//handle each template in each policy
-				handleObjectTemplates(*policy, apiresourcelist, apigroups)
+				r.handleObjectTemplates(*policy, apiresourcelist, apigroups)
 				Mx.Unlock()
 			}
 		}
@@ -243,7 +235,7 @@ func PeriodicallyExecConfigPolicies(freq uint, test bool) {
 }
 
 //handleObjectTemplates iterates through all policy templates in a given policy and processes them
-func handleObjectTemplates(plc policyv1.ConfigurationPolicy, apiresourcelist []*metav1.APIResourceList,
+func (r *ConfigurationPolicyReconciler) handleObjectTemplates(plc policyv1.ConfigurationPolicy, apiresourcelist []*metav1.APIResourceList,
 	apigroups []*restmapper.APIGroupResources) {
 	fmt.Println(fmt.Sprintf("processing object templates for policy %s...", plc.GetName()))
 	//error if no remediationAction is specified
@@ -252,8 +244,8 @@ func handleObjectTemplates(plc policyv1.ConfigurationPolicy, apiresourcelist []*
 		message := "Policy does not have a RemediationAction specified"
 		update := createViolation(&plc, 0, "No RemediationAction", message)
 		if update {
-			recorder.Event(&plc, eventWarning, fmt.Sprintf(plcFmtStr, plc.GetName()), convertPolicyStatusToString(&plc))
-			addForUpdate(&plc)
+			r.Recorder.Event(&plc, eventWarning, fmt.Sprintf(plcFmtStr, plc.GetName()), convertPolicyStatusToString(&plc))
+			r.addForUpdate(&plc)
 		}
 		return
 	}
@@ -327,8 +319,8 @@ func handleObjectTemplates(plc policyv1.ConfigurationPolicy, apiresourcelist []*
 
 				update := createViolation(&plc, 0, "Error processing hub templates", hubTemplatesErrMsg)
 				if update {
-					recorder.Event(&plc, eventWarning, fmt.Sprintf(plcFmtStr, plc.GetName()), convertPolicyStatusToString(&plc))
-					checkRelatedAndUpdate(update, plc, relatedObjects, oldRelated)
+					r.Recorder.Event(&plc, eventWarning, fmt.Sprintf(plcFmtStr, plc.GetName()), convertPolicyStatusToString(&plc))
+					r.checkRelatedAndUpdate(update, plc, relatedObjects, oldRelated)
 				}
 				return
 			}
@@ -338,8 +330,8 @@ func handleObjectTemplates(plc policyv1.ConfigurationPolicy, apiresourcelist []*
 				if tplErr != nil {
 					update := createViolation(&plc, 0, "Error processing template", tplErr.Error()) //
 					if update {
-						recorder.Event(&plc, eventWarning, fmt.Sprintf(plcFmtStr, plc.GetName()), convertPolicyStatusToString(&plc))
-						checkRelatedAndUpdate(update, plc, relatedObjects, oldRelated)
+						r.Recorder.Event(&plc, eventWarning, fmt.Sprintf(plcFmtStr, plc.GetName()), convertPolicyStatusToString(&plc))
+						r.checkRelatedAndUpdate(update, plc, relatedObjects, oldRelated)
 					}
 					return
 				}
@@ -373,8 +365,8 @@ func handleObjectTemplates(plc policyv1.ConfigurationPolicy, apiresourcelist []*
 		objNamespaced := false
 		//iterate through all namespaces the configurationpolicy is set on
 		for _, ns := range relevantNamespaces {
-			names, compliant, reason, objKind, related, update, namespaced := handleObjects(objectT, ns, indx, &plc, config,
-				recorder, apiresourcelist, apigroups)
+			names, compliant, reason, objKind, related, update, namespaced := r.handleObjects(objectT, ns, indx, &plc, config,
+				apiresourcelist, apigroups)
 			if update {
 				parentUpdate = true
 			}
@@ -429,15 +421,15 @@ func handleObjectTemplates(plc policyv1.ConfigurationPolicy, apiresourcelist []*
 			}
 		}
 	}
-	checkRelatedAndUpdate(parentUpdate, plc, relatedObjects, oldRelated)
+	r.checkRelatedAndUpdate(parentUpdate, plc, relatedObjects, oldRelated)
 }
 
 //checks related objects field and triggers an update on the configurationpolicy if it has changed
-func checkRelatedAndUpdate(update bool, plc policyv1.ConfigurationPolicy, related,
+func (r *ConfigurationPolicyReconciler) checkRelatedAndUpdate(update bool, plc policyv1.ConfigurationPolicy, related,
 	oldRelated []policyv1.RelatedObject) {
 	sortUpdate := sortRelatedObjectsAndUpdate(&plc, related, oldRelated)
 	if update || sortUpdate {
-		addForUpdate(&plc)
+		r.addForUpdate(&plc)
 	}
 }
 
@@ -561,8 +553,8 @@ func createInformStatus(mustNotHave bool, numCompliant int, numNonCompliant int,
 }
 
 //handleObjects controls the processing of each individual object template within a configurationpolicy
-func handleObjects(objectT *policyv1.ObjectTemplate, namespace string, index int, policy *policyv1.ConfigurationPolicy,
-	config *rest.Config, recorder record.EventRecorder, apiresourcelist []*metav1.APIResourceList,
+func (r *ConfigurationPolicyReconciler) handleObjects(objectT *policyv1.ObjectTemplate, namespace string, index int, policy *policyv1.ConfigurationPolicy,
+	config *rest.Config, apiresourcelist []*metav1.APIResourceList,
 	apigroups []*restmapper.APIGroupResources) (objNameList []string, compliant bool, reason string,
 	rsrcKind string, relatedObjects []policyv1.RelatedObject, pUpdate bool, isNamespaced bool) {
 	if namespace != "" {
@@ -574,7 +566,7 @@ func handleObjects(objectT *policyv1.ObjectTemplate, namespace string, index int
 	needUpdate := false
 	ext := objectT.ObjectDefinition
 	//map raw object to a resource, generate a violation if resource cannot be found
-	mapping, mappingUpdate := getMapping(apigroups, ext, policy, index)
+	mapping, mappingUpdate := r.getMapping(apigroups, ext, policy, index)
 	if mapping == nil {
 		return nil, false, "", "", nil, (needUpdate || mappingUpdate), namespaced
 	}
@@ -603,7 +595,7 @@ func handleObjects(objectT *policyv1.ObjectTemplate, namespace string, index int
 				policy.Status.CompliancyDetails[index].ComplianceState == policyv1.NonCompliant {
 				eventType = eventWarning
 			}
-			recorder.Event(policy, eventType, fmt.Sprintf(eventFmtStr, policy.GetName(), name),
+			r.Recorder.Event(policy, eventType, fmt.Sprintf(eventFmtStr, policy.GetName(), name),
 				convertPolicyStatusToString(policy))
 			needUpdate = true
 		}
@@ -629,7 +621,7 @@ func handleObjects(objectT *policyv1.ObjectTemplate, namespace string, index int
 	complianceCalculated := false
 	if len(objNames) == 1 {
 		name = objNames[0]
-		objNames, compliant, rsrcKind, needUpdate = handleSingleObj(policy, remediation, exists, objShouldExist, rsrc,
+		objNames, compliant, rsrcKind, needUpdate = r.handleSingleObj(policy, remediation, exists, objShouldExist, rsrc,
 			dclient, objectT, map[string]interface{}{
 				"name":       name,
 				"namespace":  namespace,
@@ -690,7 +682,7 @@ func generateSingleObjReason(objShouldExist bool, compliant bool, exists bool) (
 
 // handleSingleObj takes in an object template (for a named object) and its data and determines whether the object on the cluster
 // is compliant or not
-func handleSingleObj(policy *policyv1.ConfigurationPolicy, remediation policyv1.RemediationAction, exists bool,
+func (r *ConfigurationPolicyReconciler) handleSingleObj(policy *policyv1.ConfigurationPolicy, remediation policyv1.RemediationAction, exists bool,
 	objShouldExist bool, rsrc schema.GroupVersionResource, dclient dynamic.Interface, objectT *policyv1.ObjectTemplate,
 	data map[string]interface{}) (objNameList []string, compliance bool, rsrcKind string, shouldUpdate bool) {
 	var err error
@@ -772,7 +764,7 @@ func handleSingleObj(policy *policyv1.ConfigurationPolicy, remediation policyv1.
 			eventType = eventWarning
 			compliant = false
 		}
-		recorder.Event(policy, eventType, fmt.Sprintf(eventFmtStr, policy.GetName(), name),
+		r.Recorder.Event(policy, eventType, fmt.Sprintf(eventFmtStr, policy.GetName(), name),
 			convertPolicyStatusToString(policy))
 		return nil, compliant, "", updateNeeded
 	}
@@ -820,7 +812,7 @@ func getResourceAndDynamicClient(mapping *meta.RESTMapping, apiresourcelist []*m
 }
 
 // getMapping takes in a raw object, decodes it, and maps it to an existing group/kind
-func getMapping(apigroups []*restmapper.APIGroupResources, ext runtime.RawExtension,
+func (r *ConfigurationPolicyReconciler) getMapping(apigroups []*restmapper.APIGroupResources, ext runtime.RawExtension,
 	policy *policyv1.ConfigurationPolicy, index int) (mapping *meta.RESTMapping, update bool) {
 	updateNeeded := false
 	restmapper := restmapper.NewDiscoveryRESTMapper(apigroups)
@@ -895,7 +887,7 @@ func getMapping(apigroups []*restmapper.APIGroupResources, ext runtime.RawExtens
 		}
 		if updateNeeded {
 			//generate an event on the configurationpolicy if a violation is created
-			recorder.Event(policy, eventWarning, fmt.Sprintf(plcFmtStr, policy.GetName()), errMsg)
+			r.Recorder.Event(policy, eventWarning, fmt.Sprintf(plcFmtStr, policy.GetName()), errMsg)
 		}
 		return nil, updateNeeded
 	}
@@ -1552,7 +1544,7 @@ func IsSimilarToLastCondition(oldCond policyv1.Condition, newCond policyv1.Condi
 }
 
 //addForUpdate calculates the compliance status of a configurationPolicy and updates its status field if needed
-func addForUpdate(policy *policyv1.ConfigurationPolicy) {
+func (r *ConfigurationPolicyReconciler) addForUpdate(policy *policyv1.ConfigurationPolicy) {
 	compliant := true
 	for index := range policy.Spec.ObjectTemplates {
 		if index < len(policy.Status.CompliancyDetails) {
@@ -1568,7 +1560,7 @@ func addForUpdate(policy *policyv1.ConfigurationPolicy) {
 	} else {
 		policy.Status.ComplianceState = policyv1.NonCompliant
 	}
-	_, err := updatePolicyStatus(map[string]*policyv1.ConfigurationPolicy{
+	_, err := r.updatePolicyStatus(map[string]*policyv1.ConfigurationPolicy{
 		(*policy).GetName(): policy,
 	})
 	modifiedErr := "the object has been modified; please apply your changes to the latest version and try again"
@@ -1582,20 +1574,17 @@ func addForUpdate(policy *policyv1.ConfigurationPolicy) {
 
 //updatePolicyStatus updates the status of the configurationPolicy if new conditions are added and generates an event
 //on the parent policy with the complaince decision
-func updatePolicyStatus(policies map[string]*policyv1.ConfigurationPolicy) (*policyv1.ConfigurationPolicy, error) {
+func (r *ConfigurationPolicyReconciler) updatePolicyStatus(policies map[string]*policyv1.ConfigurationPolicy) (*policyv1.ConfigurationPolicy, error) {
 	for _, instance := range policies { // policies is a map where: key = plc.Name, value = pointer to plc
 		fmt.Println(fmt.Sprintf("Updating configurationPolicy status: %v", instance.Status.ComplianceState))
-		err := reconcilingAgent.Status().Update(context.TODO(), instance)
+		err := r.Status().Update(context.TODO(), instance)
 		if err != nil {
 			return instance, err
 		}
 		if EventOnParent != "no" && instance.Status.ComplianceState != "Undetermined" {
-			createParentPolicyEvent(instance)
+			r.createParentPolicyEvent(instance)
 		}
-		if reconcilingAgent.Recorder != nil {
-			reconcilingAgent.Recorder.Event(instance, "Normal", "Policy updated", fmt.Sprintf("Policy status is: %v",
-				instance.Status.ComplianceState))
-		}
+		r.Recorder.Event(instance, "Normal", "Policy updated", fmt.Sprintf("Policy status is: %v", instance.Status.ComplianceState))
 	}
 	return nil, nil
 }
@@ -1692,7 +1681,7 @@ func printMap(myMap map[string]*policyv1.ConfigurationPolicy) {
 	}
 }
 
-func createParentPolicyEvent(instance *policyv1.ConfigurationPolicy) {
+func (r *ConfigurationPolicyReconciler) createParentPolicyEvent(instance *policyv1.ConfigurationPolicy) {
 	if len(instance.OwnerReferences) == 0 {
 		return //there is nothing to do, since no owner is set
 	}
@@ -1703,17 +1692,15 @@ func createParentPolicyEvent(instance *policyv1.ConfigurationPolicy) {
 
 	parentPlc := createParentPolicy(instance)
 
-	if reconcilingAgent.Recorder != nil {
-		eventType := "Normal"
-		if instance.Status.ComplianceState == policyv1.NonCompliant {
-			eventType = "Warning"
-		}
-		fmt.Println("Creating parent policy event: " + convertPolicyStatusToString(instance))
-		reconcilingAgent.Recorder.Event(&parentPlc,
-			eventType,
-			fmt.Sprintf(eventFmtStr, instance.Namespace, instance.Name),
-			convertPolicyStatusToString(instance))
+	eventType := "Normal"
+	if instance.Status.ComplianceState == policyv1.NonCompliant {
+		eventType = "Warning"
 	}
+	fmt.Println("Creating parent policy event: " + convertPolicyStatusToString(instance))
+	r.Recorder.Event(&parentPlc,
+		eventType,
+		fmt.Sprintf(eventFmtStr, instance.Namespace, instance.Name),
+		convertPolicyStatusToString(instance))
 }
 
 func createParentPolicy(instance *policyv1.ConfigurationPolicy) extpoliciesv1.Policy {

--- a/controllers/configurationpolicy_controller_test.go
+++ b/controllers/configurationpolicy_controller_test.go
@@ -75,7 +75,7 @@ func TestReconcile(t *testing.T) {
 		},
 	}
 	var simpleClient kubernetes.Interface = testclient.NewSimpleClientset()
-	common.Initialize(&simpleClient, nil)
+	common.Initialize(simpleClient, nil)
 	res, err := r.Reconcile(context.TODO(), req)
 	if err != nil {
 		t.Fatalf("reconcile: (%v)", err)
@@ -378,7 +378,7 @@ func TestHandleAddingPolicy(t *testing.T) {
 		ObjectMeta: objMeta,
 	}
 	simpleClient.CoreV1().Namespaces().Create(context.TODO(), &ns, metav1.CreateOptions{})
-	common.Initialize(&simpleClient, nil)
+	common.Initialize(simpleClient, nil)
 	err := handleAddingPolicy(&samplePolicy)
 	assert.Nil(t, err)
 	handleRemovingPolicy(samplePolicy.GetName())

--- a/controllers/configurationpolicy_controller_test.go
+++ b/controllers/configurationpolicy_controller_test.go
@@ -345,19 +345,6 @@ func TestCompareLists(t *testing.T) {
 	assert.Equal(t, reflect.DeepEqual(fmt.Sprint(merged), fmt.Sprint(mergedExpected)), true)
 }
 
-func TestCreateParentPolicy(t *testing.T) {
-	var ownerReference = metav1.OwnerReference{
-		Name: "foo",
-	}
-	var ownerReferences = []metav1.OwnerReference{}
-	ownerReferences = append(ownerReferences, ownerReference)
-	samplePolicy.OwnerReferences = ownerReferences
-
-	policy := createParentPolicy(&samplePolicy)
-	assert.NotNil(t, policy)
-	createParentPolicyEvent(&samplePolicy)
-}
-
 func TestConvertPolicyStatusToString(t *testing.T) {
 	var compliantDetail = policiesv1alpha1.TemplateStatus{
 		ComplianceState: policiesv1alpha1.NonCompliant,

--- a/main.go
+++ b/main.go
@@ -153,14 +153,10 @@ func main() {
 	}
 
 	// Initialize some variables
-	client, err := kubernetes.NewForConfig(cfg)
-	if err != nil {
-		log.Info("cannot create kube client sucessfully: %v", err)
-	}
-	var generatedClient kubernetes.Interface = kubernetes.NewForConfigOrDie(mgr.GetConfig())
-	common.Initialize(&generatedClient, cfg)
+	clientset := kubernetes.NewForConfigOrDie(cfg)
+	common.Initialize(clientset, cfg)
+	controllers.Initialize(cfg, clientset, namespace, eventOnParent)
 
-	controllers.Initialize(cfg, client, &generatedClient, namespace, eventOnParent)
 	// PeriodicallyExecConfigPolicies is the go-routine that periodically checks the policies
 	go reconciler.PeriodicallyExecConfigPolicies(frequency, false)
 
@@ -180,7 +176,7 @@ func main() {
 
 			log.Info("Starting lease controller to report status")
 			leaseUpdater := lease.NewLeaseUpdater(
-				generatedClient,
+				clientset,
 				"config-policy-controller",
 				operatorNs,
 			)

--- a/main.go
+++ b/main.go
@@ -160,7 +160,7 @@ func main() {
 	var generatedClient kubernetes.Interface = kubernetes.NewForConfigOrDie(mgr.GetConfig())
 	common.Initialize(&generatedClient, cfg)
 
-	controllers.Initialize(cfg, client, &generatedClient, mgr, namespace, eventOnParent)
+	controllers.Initialize(cfg, client, &generatedClient, namespace, eventOnParent)
 	// PeriodicallyExecConfigPolicies is the go-routine that periodically checks the policies
 	go reconciler.PeriodicallyExecConfigPolicies(frequency, false)
 

--- a/main.go
+++ b/main.go
@@ -132,11 +132,12 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err = (&controllers.ConfigurationPolicyReconciler{
+	reconciler := controllers.ConfigurationPolicyReconciler{
 		Client:   mgr.GetClient(),
 		Scheme:   mgr.GetScheme(),
 		Recorder: mgr.GetEventRecorderFor(controllers.ControllerName),
-	}).SetupWithManager(mgr); err != nil {
+	}
+	if err = reconciler.SetupWithManager(mgr); err != nil {
 		log.Error(err, "unable to create controller", "controller", "ConfigurationPolicy")
 		os.Exit(1)
 	}
@@ -161,7 +162,7 @@ func main() {
 
 	controllers.Initialize(cfg, client, &generatedClient, mgr, namespace, eventOnParent)
 	// PeriodicallyExecConfigPolicies is the go-routine that periodically checks the policies
-	go controllers.PeriodicallyExecConfigPolicies(frequency, false)
+	go reconciler.PeriodicallyExecConfigPolicies(frequency, false)
 
 	// This lease is not related to leader election. This is to report the status of the controller
 	// to the addon framework. This can be seen in the "status" section of the ManagedClusterAddOn

--- a/pkg/common/kubeClient.go
+++ b/pkg/common/kubeClient.go
@@ -6,16 +6,17 @@ package common
 import (
 	"context"
 	base64 "encoding/base64"
+	"regexp"
+
 	"github.com/golang/glog"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
-	"regexp"
 )
 
 // KubeClient a k8s client used for k8s native resources
-var KubeClient *kubernetes.Interface
+var KubeClient kubernetes.Interface
 
 // KubeConfig is the given kubeconfig at startup
 var KubeConfig *rest.Config
@@ -23,7 +24,7 @@ var KubeConfig *rest.Config
 var HubConfig *rest.Config
 
 // Initialize to initialize some controller varaibles
-func Initialize(kClient *kubernetes.Interface, cfg *rest.Config) {
+func Initialize(kClient kubernetes.Interface, cfg *rest.Config) {
 
 	KubeClient = kClient
 	KubeConfig = cfg
@@ -33,7 +34,7 @@ func LoadHubConfig(namespace string, secretname string) (*rest.Config, error) {
 
 	if HubConfig == nil {
 
-		secretsClient := (*KubeClient).CoreV1().Secrets(namespace)
+		secretsClient := KubeClient.CoreV1().Secrets(namespace)
 		hubSecret, err := secretsClient.Get(context.TODO(), secretname, metav1.GetOptions{})
 
 		if err != nil {

--- a/pkg/common/namespace_selection.go
+++ b/pkg/common/namespace_selection.go
@@ -36,7 +36,7 @@ func GetSelectedNamespaces(included, excluded, allNamespaces []string) []string 
 //=================================================================
 //GetAllNamespaces gets the list of all namespaces from k8s
 func GetAllNamespaces() (list []string, err error) {
-	namespaces := (*KubeClient).CoreV1().Namespaces()
+	namespaces := KubeClient.CoreV1().Namespaces()
 	namespaceList, err := namespaces.List(context.TODO(), metav1.ListOptions{})
 
 	namespacesNames := []string{}

--- a/pkg/common/namespace_selection_test.go
+++ b/pkg/common/namespace_selection_test.go
@@ -95,7 +95,7 @@ func TestGetAllNamespaces(t *testing.T) {
 	}
 	var simpleClient kubernetes.Interface = testclient.NewSimpleClientset()
 	simpleClient.CoreV1().Namespaces().Create(context.TODO(), &ns, metav1.CreateOptions{})
-	Initialize(&simpleClient, nil)
+	Initialize(simpleClient, nil)
 	_, err := GetAllNamespaces()
 	assert.Nil(t, err)
 }


### PR DESCRIPTION
While preparing for some logging adjustments, I noticed some bits that I felt could be cleaned up.

Main changes:
- The global Recorder is no longer used - the reconciler's recorder is now used in all instances where events should be recorded
- More functions are methods on the Reconciler, so they can use the reconciler's recorder
- The global KubeClient (type `*kubernetes.Interface`) is removed in favor of using the global clientSet, a concrete type which implements that interface.
