### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for config-policy-controller-acm-214

### DIFF
--- a/build/Dockerfile.rhtap
+++ b/build/Dockerfile.rhtap
@@ -36,4 +36,5 @@ LABEL io.k8s.display-name="Configuration policy controller"
 LABEL io.k8s.description="The ConfigurationPolicy kind compares the desired object defined in the policy with the objects on the cluster. \
     The OperatorPolicy kind determines whether operators deployed on the cluster match the configuration in the policy."
 LABEL com.redhat.component="acm-config-policy-controller-container"
+LABEL cpe="cpe:/a:redhat:acm:2.14::el9"
 LABEL io.openshift.tags="data,images"


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
