### PR TITLE
[release-2.12] uninstallation coverage

### DIFF
--- a/build/common/Makefile.common.mk
+++ b/build/common/Makefile.common.mk
@@ -180,4 +180,4 @@ e2e-dependencies:
 GOCOVMERGE = $(LOCAL_BIN)/gocovmerge
 .PHONY: coverage-dependencies
 coverage-dependencies:
-	$(call go-get-tool,github.com/wadey/gocovmerge@v0.0.0-20160331181800-b5bfa59ec0ad)
+	$(call go-get-tool,github.com/alexfalkowski/gocovmerge/v2@v2.15.0)

--- a/test/e2e/case29_trigger_uninstall_test.go
+++ b/test/e2e/case29_trigger_uninstall_test.go
@@ -31,8 +31,8 @@ var _ = Describe("Clean up during uninstalls", Label("running-in-cluster"), Orde
 
 	It("verifies that finalizers are removed when being uninstalled", func() {
 		By("Creating two configuration policies with pruneObjectBehavior")
-		utils.Kubectl("apply", "-f", policyYAMLPath, "-n", testNamespace)
-		utils.Kubectl("apply", "-f", policy2YAMLPath, "-n", testNamespace)
+		utils.Kubectl("create", "-f", policyYAMLPath, "-n", testNamespace)
+		utils.Kubectl("create", "-f", policy2YAMLPath, "-n", testNamespace)
 
 		By("Verifying that the configuration policies are compliant and have finalizers")
 		Eventually(func(g Gomega) {


### PR DESCRIPTION
Previously, the test used `apply`, which caused the resources to have `kubectl.kubernetes.io/last-applied-configuration` annotations. But part of the point of the test was to verify that the uninstallation still works when there are no annotations on those resources.