### PR TITLE
[release-2.14] Correct compliance on no-op dryrun updates

### DIFF
--- a/controllers/configurationpolicy_controller.go
+++ b/controllers/configurationpolicy_controller.go
@@ -3313,9 +3313,10 @@ func (r *ConfigurationPolicyReconciler) checkAndUpdateResource(
 				diff = handleDiff(log, recordDiff, existingObjectCopy, mergedObjCopy, r.FullDiffs)
 			}
 
-			r.setEvaluatedObject(obj.policy, obj.existingObj, !throwSpecViolation, "")
+			// treat the object as compliant, with no updates needed
+			r.setEvaluatedObject(obj.policy, obj.existingObj, true, "")
 
-			return throwSpecViolation, "", diff, updateNeeded, updatedObj
+			return false, "", diff, false, updatedObj
 		}
 
 		diff = handleDiff(log, recordDiff, existingObjectCopy, dryRunUpdatedObj, r.FullDiffs)
@@ -3561,6 +3562,10 @@ func removeFieldsForComparison(obj *unstructured.Unstructured) {
 	)
 	// The generation might actually bump but the API output might be the same.
 	unstructured.RemoveNestedField(obj.Object, "metadata", "generation")
+
+	if len(obj.GetAnnotations()) == 0 {
+		unstructured.RemoveNestedField(obj.Object, "metadata", "annotations")
+	}
 }
 
 // setEvaluatedObject updates the cache to indicate that the ConfigurationPolicy has evaluated this

--- a/test/resources/case8_status_check/case8_parent.yaml
+++ b/test/resources/case8_status_check/case8_parent.yaml
@@ -1,0 +1,8 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: case8-parent
+spec:
+  remediationAction: inform
+  disabled: false
+  policy-templates: []

--- a/test/resources/case8_status_check/case8_service.yaml
+++ b/test/resources/case8_status_check/case8_service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: grc-policy-propagator-metrics
+  namespace: managed
+spec:
+  internalTrafficPolicy: Cluster
+  ipFamilies:
+  - IPv4
+  ipFamilyPolicy: SingleStack
+  ports:
+  - name: metrics-https
+    port: 8443
+    protocol: TCP
+    targetPort: 8443
+  selector:
+    app: grc
+    component: ocm-policy-propagator
+    release: grc
+  sessionAffinity: None
+  type: ClusterIP

--- a/test/resources/case8_status_check/case8_service_inform.yaml
+++ b/test/resources/case8_status_check/case8_service_inform.yaml
@@ -1,0 +1,40 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: ConfigurationPolicy
+metadata:
+  name: policy-service
+  namespace: managed
+  ownerReferences:
+  - apiVersion: policy.open-cluster-management.io/v1
+    kind: Policy
+    name: case8-parent
+    uid: 12345678-90ab-cdef-1234-567890abcdef # must be replaced before creation
+spec:
+  remediationAction: inform
+  severity: low
+  object-templates:
+  - complianceType: mustonlyhave
+    metadataComplianceType: musthave
+    objectDefinition:
+      apiVersion: v1
+      kind: Service
+      metadata:
+        name: grc-policy-propagator-metrics
+        namespace: managed
+      spec: # Intentionally omitting 'type' field - K8s will default to ClusterIP 
+        clusterIP: '{{ (lookup "v1" "Service" "managed" "grc-policy-propagator-metrics").spec.clusterIP }}'
+        clusterIPs:
+        - '{{ (lookup "v1" "Service" "managed" "grc-policy-propagator-metrics").spec.clusterIP }}'
+        internalTrafficPolicy: Cluster
+        ipFamilies:
+        - IPv4
+        ipFamilyPolicy: SingleStack
+        ports:
+        - name: metrics-https
+          port: 8443
+          protocol: TCP
+          targetPort: 8443
+        selector:
+          app: grc
+          component: ocm-policy-propagator
+          release: grc
+        sessionAffinity: None


### PR DESCRIPTION
Previously, the policy status would incorrectly have a noncompliant event followed immediately by a compliant event when a dryrun update would not make any changes on that object. This would cause the policy status to repeatedly update if the policy was reconciling often - for example if any of its watched objects were updating.

Now only the correct "compliant" event should be emitted in that case.

NOTE: This is a backport, but not just a cherry-pick. This incorporates some of the changes from these upstream PRs, with updates for tests:
- https://github.com/open-cluster-management-io/config-policy-controller/pull/404
- https://github.com/open-cluster-management-io/config-policy-controller/pull/377

Refs:
 - https://issues.redhat.com/browse/ACM-25742