### PR TITLE
[release-2.12] fix: use correct kubeconfig

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -34,7 +34,7 @@
                 "--log-level=3",
                 "--v=5",
                 "--enable-operator-policy=true",
-                "--target-kubeconfig-path=${workspaceFolder}/kubeconfig_managed2",
+                "--target-kubeconfig-path=${workspaceFolder}/kubeconfig_managed2_e2e",
                 "--evaluation-backoff=1",
             ],
             "env": {

--- a/Makefile
+++ b/Makefile
@@ -266,7 +266,7 @@ e2e-test-hosted-mode-coverage: E2E_TEST_ARGS = --json-report=report_e2e_hosted_m
 e2e-test-hosted-mode-coverage: COVERAGE_E2E_OUT = coverage_e2e_hosted_mode.out
 e2e-test-hosted-mode-coverage: IS_HOSTED=true
 e2e-test-hosted-mode-coverage: E2E_PROCS=2
-e2e-test-hosted-mode-coverage: export TARGET_KUBECONFIG_PATH = $(PWD)/kubeconfig_managed2
+e2e-test-hosted-mode-coverage: export TARGET_KUBECONFIG_PATH = $(PWD)/kubeconfig_managed2_e2e
 e2e-test-hosted-mode-coverage: e2e-run-instrumented e2e-test e2e-stop-instrumented
 
 .PHONY: e2e-test-running-in-cluster


### PR DESCRIPTION
Manual cherry-pick of:

- #1627
- open-cluster-management-io/config-policy-controller#431

(cherry picked from commit f1a2e8bdbb6896229e4662ac722a17bf874528b7)
