### PR TITLE
Migrate Konflux configs for ACM 2.17

### DIFF
--- a/.tekton/config-policy-controller-acm-217-pull-request.yaml
+++ b/.tekton/config-policy-controller-acm-217-pull-request.yaml
@@ -4,16 +4,17 @@ metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/stolostron/config-policy-controller?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
-    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "release-2.16"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch in ["main", "release-2.17"]
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: release-acm-216
-    appstudio.openshift.io/component: config-policy-controller-acm-216
+    appstudio.openshift.io/application: release-acm-217
+    appstudio.openshift.io/component: config-policy-controller-acm-217
     pipelines.appstudio.openshift.io/type: build
-  name: config-policy-controller-acm-216-on-push
+  name: config-policy-controller-acm-217-on-pull-request
   namespace: crt-redhat-acm-tenant
 spec:
   params:
@@ -22,7 +23,7 @@ spec:
     - name: revision
       value: '{{revision}}'
     - name: output-image
-      value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/config-policy-controller-acm-216:{{revision}}
+      value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/config-policy-controller-acm-217:on-pr-{{revision}}
     - name: path-context
       value: .
     - name: dockerfile
@@ -31,20 +32,13 @@ spec:
       value: 'true'
     - name: prefetch-input
       value: '[{"type": "gomod", "path": "."}]'
+    - name: image-expires-after
+      value: 5d
     - name: build-source-image
       value: 'true'
     - name: build-platforms
       value:
         - linux/x86_64
-        - linux/arm64
-        - linux/ppc64le
-        - linux/s390x
-    - name: additional-tags
-      value:
-        - latest
-    - name: build-args
-      value:
-        - ACM_VERSION=2.16
   pipelineRef:
     resolver: git
     params:
@@ -55,7 +49,7 @@ spec:
       - name: pathInRepo
         value: pipelines/common.yaml
   taskRunTemplate:
-    serviceAccountName: build-pipeline-config-policy-controller-acm-216
+    serviceAccountName: build-pipeline-config-policy-controller-acm-217
   workspaces:
     - name: git-auth
       secret:

--- a/.tekton/config-policy-controller-acm-217-push.yaml
+++ b/.tekton/config-policy-controller-acm-217-push.yaml
@@ -4,17 +4,16 @@ metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/stolostron/config-policy-controller?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
-    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
-    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch in ["main", "release-2.16"]
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch == "release-2.17"
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: release-acm-216
-    appstudio.openshift.io/component: config-policy-controller-acm-216
+    appstudio.openshift.io/application: release-acm-217
+    appstudio.openshift.io/component: config-policy-controller-acm-217
     pipelines.appstudio.openshift.io/type: build
-  name: config-policy-controller-acm-216-on-pull-request
+  name: config-policy-controller-acm-217-on-push
   namespace: crt-redhat-acm-tenant
 spec:
   params:
@@ -23,7 +22,7 @@ spec:
     - name: revision
       value: '{{revision}}'
     - name: output-image
-      value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/config-policy-controller-acm-216:on-pr-{{revision}}
+      value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/config-policy-controller-acm-217:{{revision}}
     - name: path-context
       value: .
     - name: dockerfile
@@ -32,13 +31,20 @@ spec:
       value: 'true'
     - name: prefetch-input
       value: '[{"type": "gomod", "path": "."}]'
-    - name: image-expires-after
-      value: 5d
     - name: build-source-image
       value: 'true'
     - name: build-platforms
       value:
         - linux/x86_64
+        - linux/arm64
+        - linux/ppc64le
+        - linux/s390x
+    - name: additional-tags
+      value:
+        - latest
+    - name: build-args
+      value:
+        - ACM_VERSION=2.16
   pipelineRef:
     resolver: git
     params:
@@ -49,7 +55,7 @@ spec:
       - name: pathInRepo
         value: pipelines/common.yaml
   taskRunTemplate:
-    serviceAccountName: build-pipeline-config-policy-controller-acm-216
+    serviceAccountName: build-pipeline-config-policy-controller-acm-217
   workspaces:
     - name: git-auth
       secret:


### PR DESCRIPTION
Automated migration via [`migrate-konflux.sh`](https://github.com/stolostron/governance-policy-framework/blob/main/build/branch-create/migrate-konflux.sh) script.

Closes #1648 