### PR TITLE
CI: Separate coverage reports for Codecov

### DIFF
--- a/.github/workflows/kind.yml
+++ b/.github/workflows/kind.yml
@@ -286,6 +286,7 @@ jobs:
           name: unit-tests
           verbose: true
           fail_ci_if_error: false
+          disable_search: true
 
       - name: Report e2e coverage to Codecov
         uses: codecov/codecov-action@v5
@@ -296,3 +297,4 @@ jobs:
           name: e2e-tests
           verbose: true
           fail_ci_if_error: false
+          disable_search: true


### PR DESCRIPTION
The intention was to have separate metrics of coverage for the unit tests and the e2e tests, but the codecov action searches for *all* coverage files by default. This change disables that behavior.


(cherry picked from commit 05f68412d670c12f0159a132f9a8ba59bba9a980)

Closes https://github.com/stolostron/config-policy-controller/issues/1669